### PR TITLE
Update helper.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "unstract-adapters"
-version = "0.1.1"
+version = "0.2.0"
 description = "Unstract Adapters"
 authors = [
     {name = "Zipstack Inc.", email = "devsupport@zipstack.com"},

--- a/src/unstract/adapters/vectordb/helper.py
+++ b/src/unstract/adapters/vectordb/helper.py
@@ -37,7 +37,14 @@ class VectorDBHelper:
             )
             local_path = f"{os.path.dirname(__file__)}/samples/"
             index = VectorStoreIndex.from_documents(
-                documents=SimpleDirectoryReader(local_path).load_data(),
+                # By default SimpleDirectoryReader discards paths which
+                # contain one or more parts that are hidden.
+                # In local, packages could be installed in a venv. This
+                # means a path can contain a ".venv" in it which will
+                # then be treated as hidden and subsequently discarded.
+                documents=SimpleDirectoryReader(
+                    local_path,exclude_hidden=False
+                ).load_data(),
                 storage_context=storage_context,
                 service_context=service_context,
             )


### PR DESCRIPTION
Fix test connection failing for local Qdrant.

By default SimpleDirectoryReader discards paths which contain one or more parts that are hidden. In local, packages could be installed in a venv. This means a path can contain a .venv in it which will then be treated as hidden and subsequently discarded.