### PR TITLE
Fixed the default URL for the Unstract-IO Community Edition

### DIFF
--- a/src/unstract/adapters/x2text/unstructured_community/src/static/json_schema.json
+++ b/src/unstract/adapters/x2text/unstructured_community/src/static/json_schema.json
@@ -16,7 +16,7 @@
       "type": "string",
       "title": "URL",
       "format": "uri",
-      "default": "http://unstract-unstructured-io:8083/general/v0/general",
+      "default": "http://unstract-unstructured-io:8000/general/v0/general",
       "description": "Provide the URL of Unstructured IO server."
     }
   }


### PR DESCRIPTION
Changing the Unstract-IO community edition default url to point to the proper one