### PR TITLE
feat: Exposed LLMWhisperer options - extraction_mode, ocr_mode

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## What
+
+...
+
+## Why
+
+...
+
+## How
+
+...
+
+## Relevant Docs
+
+-
+
+## Related Issues or PRs
+
+-
+
+## Dependencies Versions / Env Variables
+
+-
+
+## Notes on Testing
+
+...
+
+## Screenshots
+
+...
+
+## Checklist
+
+I have read and understood the [Contribution Guidelines]().

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "unstract-adapters"
-version = "0.2.1"
+version = "0.3.0"
 description = "Unstract Adapters"
 authors = [
     {name = "Zipstack Inc.", email = "devsupport@zipstack.com"},

--- a/src/unstract/adapters/x2text/constants.py
+++ b/src/unstract/adapters/x2text/constants.py
@@ -1,12 +1,4 @@
-from enum import Enum
-
-
 class X2TextConstants:
     PLATFORM_SERVICE_API_KEY = "PLATFORM_SERVICE_API_KEY"
     X2TEXT_HOST = "X2TEXT_HOST"
     X2TEXT_PORT = "X2TEXT_PORT"
-
-
-class LLMWhispererSupportedModes(Enum):
-    OCR = "ocr"
-    TEXT = "text"

--- a/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ExtractionModes(Enum):
+    OCR = "ocr"
+    TEXT = "text"
+
+
+class OCRModes(Enum):
+    LINE_PRINTER = "line-printer"
+    TEXT_DUMP = "text-dump"

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -6,9 +6,10 @@ import requests
 from requests import Response
 
 from unstract.adapters.exceptions import AdapterError
-from unstract.adapters.x2text.constants import (
-    LLMWhispererSupportedModes,
-    X2TextConstants,
+from unstract.adapters.x2text.constants import X2TextConstants
+from unstract.adapters.x2text.llm_whisperer.src.constants import (
+    ExtractionModes,
+    OCRModes,
 )
 from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
@@ -19,6 +20,8 @@ class Constants:
     URL = "url"
     TEST_CONNECTION = "test-connection"
     PROCESS = "process"
+    EXTRACTION_MODE = "extraction_mode"
+    OCR_MODE = "ocr_mode"
 
 
 class LLMWhisperer(X2TextAdapter):
@@ -52,7 +55,7 @@ class LLMWhisperer(X2TextAdapter):
         f.close()
         return schema
 
-    def __make_request(
+    def _make_request(
         self, request_type: str, **kwargs: Optional[dict[Any, Any]]
     ) -> Response:
         llm_whisperer_svc_url = (
@@ -72,18 +75,15 @@ class LLMWhisperer(X2TextAdapter):
         files = None
         if "files" in kwargs:
             files = kwargs["files"] if kwargs["files"] is not None else None
-        body = None
-        if "mode" in kwargs:
-            mode = kwargs["mode"] if kwargs["mode"] is not None else None
-            if mode is not None:
-                values = tuple(
-                    item.value for item in LLMWhispererSupportedModes
-                )
-                if mode not in values:
-                    raise AdapterError("Mode not supported")
-                body = {
-                    "mode": mode,
-                }
+
+        body = {
+            Constants.EXTRACTION_MODE: self.config.get(
+                Constants.EXTRACTION_MODE, ExtractionModes.TEXT.value
+            ),
+            Constants.OCR_MODE: self.config.get(
+                Constants.OCR_MODE, OCRModes.LINE_PRINTER.value
+            ),
+        }
 
         response = requests.post(
             llm_whisperer_svc_url, headers=headers, files=files, data=body
@@ -99,11 +99,8 @@ class LLMWhisperer(X2TextAdapter):
         try:
             input_f = open(input_file_path, "rb")
             files = {"file": input_f}
-            mode = None
-            if "mode" in kwargs:
-                mode = kwargs["mode"] if kwargs["mode"] is not None else None
-            response = self.__make_request(
-                Constants.PROCESS, files=files, mode=mode
+            response = self._make_request(
+                request_type=Constants.PROCESS, files=files, **kwargs
             )
             if response.status_code != 200:
                 logger.error(
@@ -133,7 +130,7 @@ class LLMWhisperer(X2TextAdapter):
 
     def test_connection(self) -> bool:
         try:
-            response = self.__make_request(Constants.TEST_CONNECTION)
+            response = self._make_request(Constants.TEST_CONNECTION)
             if response.status_code != 200:
                 logger.error(
                     "Error in LLM Whisperer test-connection: "

--- a/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -12,13 +12,26 @@
       "default": "",
       "description": "Provide a unique name for this adapter instance. Example: LLM Whisperer 1"
     },
-
     "url": {
       "type": "string",
       "title": "URL",
       "format": "uri",
       "default": "http://unstract-llm-whisperer:3005",
       "description": "Provide the URL of the LLM Whisperer server."
+    },
+    "extraction_mode": {
+      "type": "string",
+      "title": "Extraction Mode",
+      "enum": ["text", "ocr"],
+      "default": "text",
+      "description": "Text mode tries to extract text from PDF and falls to OCR if the PDF is a scanned image PDF. This should be your default selection. Use OCR mode if you want to force OCR to extract text. This could be useful if you are dealing with malformed PDFs."
+    },
+    "ocr_mode": {
+      "type": "string",
+      "title": "OCR Mode",
+      "enum": ["line-printer", "text-dump"],
+      "default": "line-printer",
+      "description": "Line printer mode tries to maintain the layout of the original document. This should be your default option. If the document contains tables and other complex layouts this option works very well with large LLMs. Text dump mode extracts all the text without considering layout."
     }
   }
 }


### PR DESCRIPTION
## What
- Exposed arguments for LLMWhisperer - `extraction_mode` and `ocr_mode`
- Since its a breaking change (removal of the previously supported `mode`) - I've bumped the adapter version to 0.3.0

## Why
- These parameters help control the text extraction by LLMWhisperer and it needs to be configurable by the user

## How
- These params are read when the adapter is first created - and will be a part of the `self.config` object  of the adapter

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing
- Created an adapter with different modes and tried to index on prompt studio



## Screenshots
![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/ba8acc52-8f22-4c47-9946-0978ef04c0f1)
...

## Checklist

I have read and understood the [Contribution Guidelines]().
