### PR TITLE
fix: Updated mistral to support large-latest model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "unstract-adapters"
-version = "0.3.0"
+version = "0.3.1"
 description = "Unstract Adapters"
 authors = [
     {name = "Zipstack Inc.", email = "devsupport@zipstack.com"},

--- a/src/unstract/adapters/llm/mistral/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/mistral/src/static/json_schema.json
@@ -6,7 +6,7 @@
         "mistral-tiny",
         "mistral-small",
         "mistral-medium",
-        "mistral-large"
+        "mistral-large-latest"
       ]
     }
   },


### PR DESCRIPTION
## What
- Updated mistral's model selection to include `mistral-large-latest`
- Bumped adapters to 0.3.1
**NOTE:**  Before publishing this PR, the changes from PR #8 can also go in with this same release

## Why
- This is a regression related to a recent change in PR #10 

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing
- Haven't checked it explicitly - however @gopalsamyperumal confirmed that it was tested locally with this change

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
