### PR TITLE
github action added to publish package to pypi

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,33 @@
+name: Publish Python Package
+
+on:
+  release:
+    types: 
+        - published
+
+permissions:
+    contents: read    
+
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # This permission is needed for private repositories.
+      contents: read
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+            python-version: '3.9'
+      - uses: pdm-project/setup-pdm@v3
+      
+
+      - name: Publish package distributions to PyPI
+        run: pdm publish --dry-run


### PR DESCRIPTION
## What
- added github action to publish python package into pypi server when published a release. it uses trusted publisher feature in pipy server. https://docs.pypi.org/trusted-publishers/adding-a-publisher/
NOTE : pdm publish is only in dry mode for testing it.
...

## Why
- to avoid manual intervention on pypi publish and reduce errors.
...

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
