### PR TITLE
feat: Version to be dynamic from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,8 @@ ipython_config.py
 #   in version control.
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
+.pdm-build
+.pdm-python
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "unstract-adapters"
-version = "0.4.0"
+dynamic = ["version"]
 description = "Unstract Adapters"
 authors = [
     {name = "Zipstack Inc.", email = "devsupport@zipstack.com"},
@@ -45,6 +45,10 @@ classifiers = [
   "Programming Language :: Python"
 ]
 license = {text = "MIT"}
+
+[tool.pdm.version]
+source = "file"
+path = "src/unstract/adapters/__init__.py"
 
 [tool.pdm.dev-dependencies]
 lint = [

--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "0.4.0"
+
 import logging
 from logging import NullHandler
 from typing import Any
@@ -5,3 +7,8 @@ from typing import Any
 logging.getLogger(__name__).addHandler(NullHandler())
 
 AdapterDict = dict[str, dict[str, Any]]
+
+
+def get_adapter_version() -> str:
+    """Returns the adapter package's version."""
+    return __version__


### PR DESCRIPTION
## What

- Made version to be dynamic and read from a file
- MINOR: Added a gitignore entry for pdm related files

## Why

- Makes it consistent with the SDK
- Allows for retrieving the package version at runtime, this can help with logging and gives visibility on the version of packages being used

## How

...

## Relevant Docs

- [PDM dynamic version](https://backend.pdm-project.org/metadata/#dynamic-project-version)
- PDM also supports reading version from the SCM tag however I haven't dived deeper into this yet and it can be considered if necessary later

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing
- Tried to publishing to a local PyPI server and was able to read the version at runtime
```
# Run server
pypi-server run -v -a . -P . -p 2000 --overwrite packages

# Publish to local server
pdm publish --repository http://localhost:2000/

# Pull from server
pip install --index-url http://localhost:2000 'unstract-adapters==0.4.0'
```

## Screenshots
- PyPI server logs
![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/50dac1c9-816c-420b-bc48-b7f3e277caca)
- Package published
![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/de0b9bd2-81e4-4211-a071-463b35a17d84)
- Package pulled and version checked
![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/215bc2e2-8176-4e6b-adc2-5bd3e86cadeb)


## Checklist

I have read and understood the [Contribution Guidelines]().
