### PR TITLE
github action down graded into ubuntu-20.04 from latest tag

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   pypi-publish:
     name: upload release to PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       # This permission is needed for private repositories.
       contents: read


### PR DESCRIPTION


## What

ubuntu version down graded into ubuntu 20.04 from latest ubuntu 22.04.

python versions availability list: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

## Why
PDM run failed due to python version 3.9.6 arch x64 unavailable in ubuntu 22.04. 
...

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
