### PR TITLE
changed urls to load icons from google to backend

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.2"
+__version__ = "0.5.0"
 
 import logging
 from logging import NullHandler

--- a/src/unstract/adapters/embedding/azure_open_ai/src/azure_open_ai.py
+++ b/src/unstract/adapters/embedding/azure_open_ai/src/azure_open_ai.py
@@ -42,7 +42,7 @@ class AzureOpenAI(EmbeddingAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/AzureopenAI.png"
         )
 

--- a/src/unstract/adapters/embedding/hugging_face/src/hugging_face.py
+++ b/src/unstract/adapters/embedding/hugging_face/src/hugging_face.py
@@ -40,7 +40,7 @@ class HuggingFace(EmbeddingAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/huggingface.png"
         )
 

--- a/src/unstract/adapters/embedding/open_ai/src/open_ai.py
+++ b/src/unstract/adapters/embedding/open_ai/src/open_ai.py
@@ -40,7 +40,7 @@ class OpenAI(EmbeddingAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/OpenAI.png"
         )
 

--- a/src/unstract/adapters/embedding/palm/src/palm.py
+++ b/src/unstract/adapters/embedding/palm/src/palm.py
@@ -38,7 +38,7 @@ class PaLM(EmbeddingAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/PaLM.png"
         )
 

--- a/src/unstract/adapters/embedding/qdrant_fast_embed/src/qdrant_fast_embed.py
+++ b/src/unstract/adapters/embedding/qdrant_fast_embed/src/qdrant_fast_embed.py
@@ -37,7 +37,7 @@ class QdrantFastEmbedM(EmbeddingAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/qdrant.png"
         )
 

--- a/src/unstract/adapters/llm/anthropic/src/anthropic.py
+++ b/src/unstract/adapters/llm/anthropic/src/anthropic.py
@@ -36,7 +36,7 @@ class AnthropicLLM(LLMAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/Anthropic.png"
         )
 

--- a/src/unstract/adapters/llm/any_scale/src/anyscale.py
+++ b/src/unstract/adapters/llm/any_scale/src/anyscale.py
@@ -36,7 +36,7 @@ class AnyScaleLLM(LLMAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/anyscale.png"
         )
 

--- a/src/unstract/adapters/llm/azure_open_ai/src/azure_open_ai.py
+++ b/src/unstract/adapters/llm/azure_open_ai/src/azure_open_ai.py
@@ -40,7 +40,7 @@ class AzureOpenAILLM(LLMAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/AzureopenAI.png"
         )
 

--- a/src/unstract/adapters/llm/mistral/src/mistral.py
+++ b/src/unstract/adapters/llm/mistral/src/mistral.py
@@ -35,7 +35,7 @@ class MistralLLM(LLMAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/Mistral%20AI.png"
         )
 

--- a/src/unstract/adapters/llm/open_ai/src/open_ai.py
+++ b/src/unstract/adapters/llm/open_ai/src/open_ai.py
@@ -39,7 +39,7 @@ class OpenAILLM(LLMAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/OpenAI.png"
         )
 

--- a/src/unstract/adapters/llm/palm/src/palm.py
+++ b/src/unstract/adapters/llm/palm/src/palm.py
@@ -35,7 +35,7 @@ class PaLMLLM(LLMAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/PaLM.png"
         )
 

--- a/src/unstract/adapters/llm/replicate/src/replicate.py
+++ b/src/unstract/adapters/llm/replicate/src/replicate.py
@@ -33,7 +33,7 @@ class ReplicateLLM(LLMAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/Replicate.png"
         )
 

--- a/src/unstract/adapters/llm/vertex_ai/src/vertex_ai.py
+++ b/src/unstract/adapters/llm/vertex_ai/src/vertex_ai.py
@@ -36,7 +36,7 @@ class VertexAILLM(LLMAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/VertexAI.png"
         )
 

--- a/src/unstract/adapters/ocr/google_document_ai/src/google_document_ai.py
+++ b/src/unstract/adapters/ocr/google_document_ai/src/google_document_ai.py
@@ -55,7 +55,7 @@ class GoogleDocumentAI(OCRAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/GoogleDocumentAI.png"
         )
 

--- a/src/unstract/adapters/vectordb/milvus/src/milvus.py
+++ b/src/unstract/adapters/vectordb/milvus/src/milvus.py
@@ -39,7 +39,7 @@ class Milvus(VectorDBAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/Milvus.png"
         )
 

--- a/src/unstract/adapters/vectordb/pinecone/src/pinecone.py
+++ b/src/unstract/adapters/vectordb/pinecone/src/pinecone.py
@@ -41,7 +41,7 @@ class Pinecone(VectorDBAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/pinecone.png"
         )
 

--- a/src/unstract/adapters/vectordb/postgres/src/postgres.py
+++ b/src/unstract/adapters/vectordb/postgres/src/postgres.py
@@ -43,7 +43,7 @@ class Postgres(VectorDBAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/postgres.png"
         )
 

--- a/src/unstract/adapters/vectordb/qdrant/src/qdrant.py
+++ b/src/unstract/adapters/vectordb/qdrant/src/qdrant.py
@@ -40,7 +40,7 @@ class Qdrant(VectorDBAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/qdrant.png"
         )
 

--- a/src/unstract/adapters/vectordb/supabase/src/supabase.py
+++ b/src/unstract/adapters/vectordb/supabase/src/supabase.py
@@ -42,7 +42,7 @@ class Supabase(VectorDBAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/supabase.png"
         )
 

--- a/src/unstract/adapters/vectordb/weaviate/src/weaviate.py
+++ b/src/unstract/adapters/vectordb/weaviate/src/weaviate.py
@@ -41,7 +41,7 @@ class Weaviate(VectorDBAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/Weaviate.png"
         )
 

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -43,7 +43,7 @@ class LLMWhisperer(X2TextAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/LLMWhisperer.png"
         )
 

--- a/src/unstract/adapters/x2text/unstructured_community/src/unstructured_community.py
+++ b/src/unstract/adapters/x2text/unstructured_community/src/unstructured_community.py
@@ -28,7 +28,7 @@ class UnstructuredCommunity(X2TextAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/UnstructuredIO.png"
         )
 

--- a/src/unstract/adapters/x2text/unstructured_enterprise/src/unstructured_enterprise.py
+++ b/src/unstract/adapters/x2text/unstructured_enterprise/src/unstructured_enterprise.py
@@ -28,7 +28,7 @@ class UnstructuredEnterprise(X2TextAdapter):
     @staticmethod
     def get_icon() -> str:
         return (
-            "https://storage.googleapis.com/pandora-static/"
+            "/api/v1/static/icons/"
             "adapter-icons/UnstructuredIO.png"
         )
 


### PR DESCRIPTION
## Related PR 
- https://github.com/Zipstack/unstract/pull/126

## What

- Changed urls of load adapter icons to django backend

## Why

- Icons was loading from google 

## How

- Changed URLs to django backend

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
