### PR TITLE
fix: Made OCR related options appear for LLM whisperer

### DIFF
--- a/src/unstract/adapters/vectordb/postgres/src/static/json_schema.json
+++ b/src/unstract/adapters/vectordb/postgres/src/static/json_schema.json
@@ -37,7 +37,9 @@
     },
     "password": {
       "type": "string",
-      "title": "Password"
+      "title": "Password",
+      "format": "password",
+      "default": ""
     }
   }
 }

--- a/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -36,6 +36,12 @@
       "default": "text",
       "description": "Text mode tries to extract text from PDF and falls to OCR if the PDF is a scanned image PDF. This should be your default selection. Use OCR mode if you want to force OCR to extract text. This could be useful if you are dealing with malformed PDFs."
     },
+    "force_text_processing": {
+      "type": "boolean",
+      "title": "Force Text Processing",
+      "default": false,
+      "description": "If checked, ensures that only text processing runs and there is no OCR involved. This differs from the default behaviour where we fall back to OCR processing in case of failures with text processing."
+    },
     "output_mode": {
       "type": "string",
       "title": "Output Mode",
@@ -58,6 +64,21 @@
       "title": "Gaussian Blur Radius",
       "default": 0.0,
       "description": "The radius of the gaussian blur to use for pre-processing the image during OCR based extraction. Useful to eliminate noise from the image. Default is 0.0 if the value is not explicitly set."
+    }
+  },
+  "if": {
+    "properties": {
+      "force_text_processing": {
+        "const": "false"
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "required": [
+        "median_filter_size",
+        "gaussian_blur_radius"
+      ]
     }
   }
 }

--- a/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -29,37 +29,35 @@
     "processing_mode": {
       "type": "string",
       "title": "Processing Mode",
-      "enum": ["text", "ocr"],
+      "enum": [
+        "text",
+        "ocr"
+      ],
       "default": "text",
       "description": "Text mode tries to extract text from PDF and falls to OCR if the PDF is a scanned image PDF. This should be your default selection. Use OCR mode if you want to force OCR to extract text. This could be useful if you are dealing with malformed PDFs."
     },
     "output_mode": {
       "type": "string",
       "title": "Output Mode",
-      "enum": ["line-printer", "dump-text", "text"],
+      "enum": [
+        "line-printer",
+        "dump-text",
+        "text"
+      ],
       "default": "line-printer",
       "description": "The output format. Valid options are line-printer, dump-text and text. The line-printer mode tries to maintain the layout of the original text and works very well as inputs to LLMs. dump-text just dumps each page as paragraphs. text extracts text into groups as it sees in the original page. text and dump-text are treated as same in ocr processing mode."
-    }
-  },
-  "if":{
-    "properties": {
-      "processing_mode": { "const":"ocr" }
-    }
-  },
-  "then": {
-    "properties": {
-      "median_filter_size": {
-        "type": "integer",
-        "title": "Median Filter Size",
-        "default": 3,
-        "description": "The size of the median filter to use for pre-processing the image during OCR based extraction. Useful to eliminate scanning artifacts and low quality JPEG artifacts. Default is 3 if the value is not explicitly set."
-      },
-      "gaussian_blur_radius": {
-        "type": "number",
-        "title": "Gaussian Blur Radius",
-        "default": 1.0,
-        "description": "The radius of the gaussian blur to use for pre-processing the image during OCR based extraction. Useful to eliminate noise from the image. Default is 1.0 if the value is not explicitly set."
-      }
+    },
+    "median_filter_size": {
+      "type": "integer",
+      "title": "Median Filter Size",
+      "default": 0,
+      "description": "The size of the median filter to use for pre-processing the image during OCR based extraction. Useful to eliminate scanning artifacts and low quality JPEG artifacts. Default is 0 if the value is not explicitly set."
+    },
+    "gaussian_blur_radius": {
+      "type": "number",
+      "title": "Gaussian Blur Radius",
+      "default": 0.0,
+      "description": "The radius of the gaussian blur to use for pre-processing the image during OCR based extraction. Useful to eliminate noise from the image. Default is 0.0 if the value is not explicitly set."
     }
   }
 }


### PR DESCRIPTION
## What

- Made options for OCR - `gaussian blur radius` and `median filter size` appear at all times
- Added option `force_text_processing` and defaulted it to false
- Adapters version was not bumped explicitly since it'd done in [this PR](https://github.com/Zipstack/unstract-adapters/pull/23)
- Made password field of postgres vectorDB as protected


## Why

- These settings are using even in case of `text` mode since `ocr` works internally in case of failures. They need to be configurable in that case
- In case `Force text processing` is True - we need not use OCR at all so these fields need not be present. A todo item is to render them conditionally - due to the time constraint we'll proceed with this

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/14e5d272-1e94-47d6-a92e-0a05ea5ed262)

## Checklist

I have read and understood the [Contribution Guidelines]().
