### PR TITLE
fix: Whisperer fix for passing force text processing

### DIFF
--- a/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
@@ -37,10 +37,12 @@ class WhispererConfig:
     UNSTRACT_KEY = "unstract_key"
     MEDIAN_FILTER_SIZE = "median_filter_size"
     GAUSSIAN_BLUR_RADIUS = "gaussian_blur_radius"
+    FORCE_TEXT_PROCESSING = "force_text_processing"
 
 
-class OCRDefaults:
+class WhispererDefaults:
     """Defaults meant for OCR mode."""
 
-    MEDIAN_FILTER_SIZE = 3
-    GAUSSIAN_BLUR_RADIUS = 1.0
+    MEDIAN_FILTER_SIZE = 0
+    GAUSSIAN_BLUR_RADIUS = 0.0
+    FORCE_TEXT_PROCESSING = False

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -11,10 +11,10 @@ from unstract.adapters.utils import AdapterUtils
 from unstract.adapters.x2text.constants import X2TextConstants
 from unstract.adapters.x2text.llm_whisperer.src.constants import (
     HTTPMethod,
-    OCRDefaults,
     OutputModes,
     ProcessingModes,
     WhispererConfig,
+    WhispererDefaults,
     WhispererEndpoint,
     WhispererHeader,
 )
@@ -42,10 +42,7 @@ class LLMWhisperer(X2TextAdapter):
 
     @staticmethod
     def get_icon() -> str:
-        return (
-            "/icons/"
-            "adapter-icons/LLMWhisperer.png"
-        )
+        return "/icons/" "adapter-icons/LLMWhisperer.png"
 
     @staticmethod
     def get_json_schema() -> str:
@@ -133,20 +130,21 @@ class LLMWhisperer(X2TextAdapter):
                 WhispererConfig.OUTPUT_MODE: self.config.get(
                     WhispererConfig.OUTPUT_MODE, OutputModes.LINE_PRINTER.value
                 ),
+                WhispererConfig.FORCE_TEXT_PROCESSING: self.config.get(
+                    WhispererConfig.FORCE_TEXT_PROCESSING,
+                    WhispererDefaults.FORCE_TEXT_PROCESSING,
+                ),
             }
-            if (
-                params[WhispererConfig.PROCESSING_MODE]
-                == ProcessingModes.OCR.value
-            ):
+            if not params[WhispererConfig.FORCE_TEXT_PROCESSING]:
                 params.update(
                     {
                         WhispererConfig.MEDIAN_FILTER_SIZE: self.config.get(
                             WhispererConfig.MEDIAN_FILTER_SIZE,
-                            OCRDefaults.MEDIAN_FILTER_SIZE,
+                            WhispererDefaults.MEDIAN_FILTER_SIZE,
                         ),
                         WhispererConfig.GAUSSIAN_BLUR_RADIUS: self.config.get(
                             WhispererConfig.GAUSSIAN_BLUR_RADIUS,
-                            OCRDefaults.GAUSSIAN_BLUR_RADIUS,
+                            WhispererDefaults.GAUSSIAN_BLUR_RADIUS,
                         ),
                     }
                 )


### PR DESCRIPTION
## What

- Updated LLM whisperer adapter to pass arguments based on the `FORCE_TEXT_PROCESSING` field

**NOTE: Version was not bumped, it can be done along with @gaya3-zipstack 's changes**
## Why

- This was missed in a recent change meant to force text processing #24 

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

- Tested locally with the public LLM whisperer service

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
