### PR TITLE
Qdrant client version roll up

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
         "vecs==0.4.3",
         "pinecone-client==2.2.4",
         "psycopg2-binary==2.9.9",
-        #Any change
         "qdrant-client~=1.8.0",
         "supabase==2.2.1",
         "weaviate-client==3.25.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
         "vecs==0.4.3",
         "pinecone-client==2.2.4",
         "psycopg2-binary==2.9.9",
-        "qdrant-client==1.7.0",
+        #Any change
+        "qdrant-client~=1.8.0",
         "supabase==2.2.1",
         "weaviate-client==3.25.3",
         #Required by postgres

--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 import logging
 from logging import NullHandler


### PR DESCRIPTION
## What

Qdrant client version roll up

## Why

...

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

Unable to generate pdm. lock with this as for some reason, pin resolution is looping forever with boto3. Tried alternates like pinning down boto3. But no luck. Since pdm.lock for adapters is only used by developers, @chandrasekharan-zipstack and @gaya3-zipstack have decided to skip this.

## Screenshots

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/56fa1ebf-3144-41b3-be7a-5fa139029a5a)


## Checklist

I have read and understood the [Contribution Guidelines]().
