### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions are currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| < 0.7  | :x:                |
+| 0.7.x  | :white_check_mark: |
+| > 0.7  | :white_check_mark: |
+
+## Reporting a Vulnerability or Security Issue
+
+The Unstract team and community take security issues very seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a vulnerability or security issue, please use the GitHub Security Advisory page ["Report a Vulnerability"](https://github.com/Zipstack/unstract-adapters/security/advisories/) button.
+
+The Unstract team will send a response indicating the next steps in handling the reported issue. After the initial reply to your report, the Unstract team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.


### PR DESCRIPTION
## What

Add a security policy.

## Why

- To pass check for security policy in [community standards](https://github.com/Zipstack/unstract-adapters/community).
- Enable vulnerability reporters to privately and easily disclose security risks to repository maintainers.

## How

- [Enable Private vulnerability reporting](https://github.com/Zipstack/unstract-adapters/security) repository security setting
- Admins and maintainers of this repository will be able to [manage privately reported security vulnerabilities](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/managing-privately-reported-security-vulnerabilities) at repository [Security Advisory page](https://github.com/Zipstack/unstract-adapters/security/advisories)
- Vulnerability reporters will be able to see the published security advisories instead at the same repository [Security Advisory page](https://github.com/Zipstack/unstract-adapters/security/advisories) and use `Report a new vulnerability` button to report a new vulnerability, see [here](https://github.com/electron/electron/security/) for example
- Maintainers and vulnerability reporters can then [coordinate to resolve the reported vulnerability issue](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)

## Relevant Docs

- [Add security policy to repository](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)
- [Coordinated disclosure of security vulnerabilities](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/about-coordinated-disclosure-of-security-vulnerabilities) - **standard** and **private** types out of which **private** reporting is better
- [Private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/about-coordinated-disclosure-of-security-vulnerabilities#private-vulnerability-reporting)

## Checklist

I have read and understood the [Contribution Guidelines]().
