### PR TITLE
Fix Pinecone collection name issue

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 import logging
 from logging import NullHandler

--- a/src/unstract/adapters/vectordb/pinecone/src/pinecone.py
+++ b/src/unstract/adapters/vectordb/pinecone/src/pinecone.py
@@ -65,8 +65,9 @@ class Pinecone(VectorDBAdapter):
                 self.config.get(VectorDbConstants.VECTOR_DB_NAME),
                 self.config.get(VectorDbConstants.EMBEDDING_DIMENSION),
             )
-            # Piecone allows only alphanumeric & hyphens for collection naming
-            self.collection_name = collection_name.replace("_", "-")
+            # Pinecone allows only lowercase alphanumeric & hyphens for
+            # collection name
+            self.collection_name = collection_name.replace("_", "-").lower()
             dimension = self.config.get(
                 VectorDbConstants.EMBEDDING_DIMENSION,
                 VectorDbConstants.DEFAULT_EMBEDDING_SIZE,


### PR DESCRIPTION
## What

Pinecone only allows lower case letters/numbers/hyphens for an index name. Our org names have a upper case letters ("org_HJqNgodUQsA99S3A_unstract_1536") also and while creating vector db with such names, Pinecone throws an error


## Why

Pinecone internals

## How

Convert to lower case before passing on to create the collection.

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
