### PR TITLE
feat: Changes to support async extraction in LLM whisperer

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 
 import logging

--- a/src/unstract/adapters/x2text/llm_whisperer/README.md
+++ b/src/unstract/adapters/x2text/llm_whisperer/README.md
@@ -1,1 +1,10 @@
 # Unstract LLM Whisperer X2Text Adapter
+
+## Env variables
+
+The below env variables are resolved by LLM Whisperer adapter
+
+| Variable                     | Description                                                                                  |
+| ---------------------------- | -------------------------------------------------------------------------------------------- |
+| `ADAPTER_LLMW_POLL_INTERVAL` | Time in seconds to wait before polling LLMWhisperer's status API. Defaults to 30s            |
+| `ADAPTER_LLMW_MAX_POLLS`     | Total number of times to poll the status API. Set to -1 to poll indefinitely. Defaults to -1 |

--- a/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
@@ -1,3 +1,4 @@
+import os
 from enum import Enum
 
 
@@ -26,6 +27,24 @@ class WhispererEndpoint:
 
     TEST_CONNECTION = "test-connection"
     WHISPER = "whisper"
+    STATUS = "whisper-status"
+    RETRIEVE = "whisper-retrieve"
+
+
+class WhispererEnv:
+    """Env variables for LLM whisperer.
+
+    Can be used to alter behaviour at runtime.
+
+    Attributes:
+        POLL_INTERVAL: Time in seconds to wait before polling
+            LLMWhisperer's status API. Defaults to 30s
+        MAX_POLLS: Total number of times to poll the status API.
+            Set to -1 to poll indefinitely. Defaults to -1
+    """
+
+    POLL_INTERVAL = "ADAPTER_LLMW_POLL_INTERVAL"
+    MAX_POLLS = "ADAPTER_LLMW_MAX_POLLS"
 
 
 class WhispererConfig:
@@ -40,9 +59,23 @@ class WhispererConfig:
     FORCE_TEXT_PROCESSING = "force_text_processing"
 
 
+class WhisperStatus:
+    """Values returned / used by /whisper-status endpoint."""
+
+    PROCESSING = "processing"
+    PROCESSED = "processed"
+    DELIVERED = "delivered"
+    UNKNOWN = "unknown"
+    # Used for async processing
+    WHISPER_HASH = "whisper-hash"
+    STATUS = "status"
+
+
 class WhispererDefaults:
-    """Defaults meant for OCR mode."""
+    """Defaults meant for LLM whisperer."""
 
     MEDIAN_FILTER_SIZE = 0
     GAUSSIAN_BLUR_RADIUS = 0.0
     FORCE_TEXT_PROCESSING = False
+    POLL_INTERVAL = os.getenv(WhispererEnv.POLL_INTERVAL, 30)
+    MAX_POLLS = os.getenv(WhispererEnv.MAX_POLLS, -1)

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -1,15 +1,14 @@
 import logging
 import os
+import time
 from typing import Any, Optional
 
 import requests
 from requests import Response
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 
-from unstract.adapters.exceptions import AdapterError
+from unstract.adapters.exceptions import ExtractorError
 from unstract.adapters.utils import AdapterUtils
-from unstract.adapters.x2text.constants import X2TextConstants
-from unstract.adapters.x2text.helper import X2TextHelper
 from unstract.adapters.x2text.llm_whisperer.src.constants import (
     HTTPMethod,
     OutputModes,
@@ -18,6 +17,7 @@ from unstract.adapters.x2text.llm_whisperer.src.constants import (
     WhispererDefaults,
     WhispererEndpoint,
     WhispererHeader,
+    WhisperStatus,
 )
 from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
@@ -52,40 +52,53 @@ class LLMWhisperer(X2TextAdapter):
         f.close()
         return schema
 
-    def _make_request(
-        self,
-        request_method: HTTPMethod,
-        request_endpoint: str,
-        params: Optional[dict[str, Any]] = None,
-        files: Optional[dict[Any, Any]] = None,
-    ) -> Response:
-        llm_whisperer_svc_url = (
-            f"{self.config.get(WhispererConfig.URL)}" f"/v1/{request_endpoint}"
-        )
-        # Required when whisperer service is run locally
-        platform_service_api_key = self.config.get(
-            X2TextConstants.PLATFORM_SERVICE_API_KEY
-        )
+    def _get_request_headers(self) -> dict[str, Any]:
+        """Obtains the request headers to authenticate with LLM Whisperer.
 
-        headers = {
+        Returns:
+            str: Request headers
+        """
+        return {
             "accept": "application/json",
-            "Authorization": f"Bearer {platform_service_api_key}",
             WhispererHeader.UNSTRACT_KEY: self.config.get(
                 WhispererConfig.UNSTRACT_KEY
             ),
         }
 
-        data = None
-        if files is not None:
-            f = files["file"]
-            data = f.read()
-            headers["Content-Type"] = "application/octet-stream"
+    def _make_request(
+        self,
+        request_method: HTTPMethod,
+        request_endpoint: str,
+        headers: Optional[dict[str, Any]] = None,
+        params: Optional[dict[str, Any]] = None,
+        data: Optional[Any] = None,
+    ) -> Response:
+        """Makes a request to LLM whisperer service.
+
+        Args:
+            request_method (HTTPMethod): HTTPMethod to call. Can be GET or POST
+            request_endpoint (str): LLM whisperer endpoint to hit
+            headers (Optional[dict[str, Any]], optional): Headers to pass.
+                Defaults to None.
+            params (Optional[dict[str, Any]], optional): Query params to pass.
+                Defaults to None.
+            data (Optional[Any], optional): Data to pass in case of POST.
+                Defaults to None.
+
+        Returns:
+            Response: Response from the request
+        """
+        llm_whisperer_svc_url = (
+            f"{self.config.get(WhispererConfig.URL)}" f"/v1/{request_endpoint}"
+        )
+        if not headers:
+            headers = self._get_request_headers()
 
         try:
             response: Response
             if request_method == HTTPMethod.GET:
                 response = requests.get(
-                    url=llm_whisperer_svc_url, headers=headers
+                    url=llm_whisperer_svc_url, headers=headers, params=params
                 )
             elif request_method == HTTPMethod.POST:
                 response = requests.post(
@@ -95,91 +108,63 @@ class LLMWhisperer(X2TextAdapter):
                     data=data,
                 )
             else:
-                raise AdapterError(
+                raise ExtractorError(
                     f"Unsupported request method: {request_method}"
                 )
             response.raise_for_status()
         except ConnectionError as e:
             logger.error(f"Adapter error: {e}")
-            raise AdapterError(
+            raise ExtractorError(
                 "Unable to connect to LLM Whisperer service, "
                 "please check the URL"
             )
         except Timeout as e:
             msg = "Request to LLM whisperer has timed out"
             logger.error(f"{msg}: {e}")
-            raise AdapterError(msg)
+            raise ExtractorError(msg)
         except HTTPError as e:
             logger.error(f"Adapter error: {e}")
             default_err = "Error while calling the LLM Whisperer service"
             msg = AdapterUtils.get_msg_from_request_exc(
                 err=e, message_key="message", default_err=default_err
             )
-            raise AdapterError(msg)
+            raise ExtractorError(msg)
         return response
 
-    def process(
-        self,
-        input_file_path: str,
-        output_file_path: Optional[str] = None,
-        **kwargs: dict[Any, Any],
-    ) -> str:
-        try:
-            input_f = open(input_file_path, "rb")
-            files = {"file": input_f}
+    def _get_whisper_params(self) -> dict[str, Any]:
+        """Gets query params meant for /whisper endpoint.
 
-            params = {
-                WhispererConfig.PROCESSING_MODE: self.config.get(
-                    WhispererConfig.PROCESSING_MODE, ProcessingModes.TEXT.value
-                ),
-                WhispererConfig.OUTPUT_MODE: self.config.get(
-                    WhispererConfig.OUTPUT_MODE, OutputModes.LINE_PRINTER.value
-                ),
-                WhispererConfig.FORCE_TEXT_PROCESSING: self.config.get(
-                    WhispererConfig.FORCE_TEXT_PROCESSING,
-                    WhispererDefaults.FORCE_TEXT_PROCESSING,
-                ),
-            }
-            if not params[WhispererConfig.FORCE_TEXT_PROCESSING]:
-                params.update(
-                    {
-                        WhispererConfig.MEDIAN_FILTER_SIZE: self.config.get(
-                            WhispererConfig.MEDIAN_FILTER_SIZE,
-                            WhispererDefaults.MEDIAN_FILTER_SIZE,
-                        ),
-                        WhispererConfig.GAUSSIAN_BLUR_RADIUS: self.config.get(
-                            WhispererConfig.GAUSSIAN_BLUR_RADIUS,
-                            WhispererDefaults.GAUSSIAN_BLUR_RADIUS,
-                        ),
-                    }
-                )
+        The params is filled based on the configuration passed.
 
-            response = self._make_request(
-                request_method=HTTPMethod.POST,
-                request_endpoint=WhispererEndpoint.WHISPER,
-                params=params,
-                files=files,
+        Returns:
+            dict[str, Any]: Query params
+        """
+        params = {
+            WhispererConfig.PROCESSING_MODE: self.config.get(
+                WhispererConfig.PROCESSING_MODE, ProcessingModes.TEXT.value
+            ),
+            WhispererConfig.OUTPUT_MODE: self.config.get(
+                WhispererConfig.OUTPUT_MODE, OutputModes.LINE_PRINTER.value
+            ),
+            WhispererConfig.FORCE_TEXT_PROCESSING: self.config.get(
+                WhispererConfig.FORCE_TEXT_PROCESSING,
+                WhispererDefaults.FORCE_TEXT_PROCESSING,
+            ),
+        }
+        if not params[WhispererConfig.FORCE_TEXT_PROCESSING]:
+            params.update(
+                {
+                    WhispererConfig.MEDIAN_FILTER_SIZE: self.config.get(
+                        WhispererConfig.MEDIAN_FILTER_SIZE,
+                        WhispererDefaults.MEDIAN_FILTER_SIZE,
+                    ),
+                    WhispererConfig.GAUSSIAN_BLUR_RADIUS: self.config.get(
+                        WhispererConfig.GAUSSIAN_BLUR_RADIUS,
+                        WhispererDefaults.GAUSSIAN_BLUR_RADIUS,
+                    ),
+                }
             )
-            output, is_success = X2TextHelper.parse_response(
-                response=response, out_file_path=output_file_path
-            )
-            if not is_success:
-                raise AdapterError("Couldn't extract text from file")
-            return output  # type: ignore
-        except OSError as e:
-            msg = f"OS error while reading {input_file_path} "
-            if output_file_path:
-                msg += f"and writing {output_file_path}"
-            msg += f": {str(e)}"
-            logger.error(msg)
-            raise AdapterError(str(e))
-        # TODO: Review this practice and remove if unnecessary
-        except Exception as e:
-            logger.error(f"Error occured while processing document: {e}")
-            raise AdapterError(str(e))
-        finally:
-            if input_f is not None:
-                input_f.close()
+        return params
 
     def test_connection(self) -> bool:
         self._make_request(
@@ -187,3 +172,152 @@ class LLMWhisperer(X2TextAdapter):
             request_endpoint=WhispererEndpoint.TEST_CONNECTION,
         )
         return True
+
+    def _check_status_until_ready(
+        self, whisper_hash: str, headers: dict[str, Any], params: dict[str, Any]
+    ) -> WhisperStatus:
+        """Checks the extraction status by polling.
+
+        Polls the /whisper-status endpoint in fixed intervals of
+        env: ADAPTER_LLMW_POLL_INTERVAL for a certain number of times
+        controlled by env: ADAPTER_LLMW_MAX_POLLS.
+
+        Args:
+            whisper_hash (str): Identifier for the extraction,
+                returned by LLMWhisperer
+            headers (dict[str, Any]): Headers to pass for the status check
+            params (dict[str, Any]): Params to pass for the status check
+
+        Returns:
+            WhisperStatus: Status of the extraction
+        """
+        POLL_INTERVAL = WhispererDefaults.POLL_INTERVAL
+        MAX_POLLS = WhispererDefaults.MAX_POLLS
+        request_count = 0
+
+        # Check status in fixed intervals upto max poll count.
+        # If max poll count is -1, check happens indefinitely
+        while True:
+            request_count += 1
+            logger.info(
+                f"Checking status with interval: {POLL_INTERVAL}s"
+                f", request count: {request_count} [max: {MAX_POLLS}]"
+            )
+            status_response = self._make_request(
+                request_method=HTTPMethod.GET,
+                request_endpoint=WhispererEndpoint.STATUS,
+                headers=headers,
+                params=params,
+            )
+            if status_response.status_code == 200:
+                status_data = status_response.json()
+                status = status_data.get(
+                    WhisperStatus.STATUS, WhisperStatus.UNKNOWN
+                )
+                logger.info(f"Whisper status for {whisper_hash}: {status}")
+                if status in [WhisperStatus.PROCESSED, WhisperStatus.DELIVERED]:
+                    break
+            else:
+                raise ExtractorError(
+                    "Error checking LLMWhisperer status: "
+                    f"{status_response.status_code} - {status_response.text}"
+                )
+
+            # Exit with error if max poll count is reached
+            if request_count == MAX_POLLS:
+                raise ExtractorError(
+                    "Unable to extract text after attempting"
+                    f" {MAX_POLLS} times"
+                )
+            time.sleep(POLL_INTERVAL)
+
+        return status
+
+    def _extract_async(self, whisper_hash: str) -> str:
+        """Makes an async extraction with LLMWhisperer.
+
+        Polls and checks the status first before proceeding to retrieve once.
+
+        Args:
+            whisper_hash (str): Identifier of the extraction
+
+        Returns:
+            str: Extracted contents from the file
+        """
+        logger.info(f"Extracting async for whisper hash: {whisper_hash}")
+
+        headers: dict[str, Any] = self._get_request_headers()
+        params = {WhisperStatus.WHISPER_HASH: whisper_hash}
+
+        # Polls in fixed intervals and checks status
+        self._check_status_until_ready(
+            whisper_hash=whisper_hash, headers=headers, params=params
+        )
+
+        retrieve_response = self._make_request(
+            request_method=HTTPMethod.GET,
+            request_endpoint=WhispererEndpoint.RETRIEVE,
+            headers=headers,
+            params=params,
+        )
+        if retrieve_response.status_code == 200:
+            return retrieve_response.content.decode("utf-8")
+        else:
+            raise ExtractorError(
+                "Error retrieving from LLMWhisperer: "
+                f"{retrieve_response.status_code} - {retrieve_response.text}"
+            )
+
+    def process(
+        self,
+        input_file_path: str,
+        output_file_path: Optional[str] = None,
+        **kwargs: dict[Any, Any],
+    ) -> str:
+        """Used to extract text from documents.
+
+        Args:
+            input_file_path (str): Path to file that needs to be extracted
+            output_file_path (Optional[str], optional): File path to write
+                extracted text into, if None doesn't write to a file.
+                Defaults to None.
+
+        Returns:
+            str: Extracted text
+        """
+        headers = self._get_request_headers()
+        headers["Content-Type"] = "application/octet-stream"
+        params = self._get_whisper_params()
+
+        response: requests.Response
+        try:
+            with open(input_file_path, "rb") as input_f:
+                response = self._make_request(
+                    request_method=HTTPMethod.POST,
+                    request_endpoint=WhispererEndpoint.WHISPER,
+                    headers=headers,
+                    params=params,
+                    data=input_f.read(),
+                )
+        except OSError as e:
+            logger.error(f"OS error while reading {input_file_path}: {e}")
+            raise ExtractorError(str(e))
+
+        output = ""
+        if response.status_code == 200:
+            output = response.content.decode("utf-8")
+        elif response.status_code == 202:
+            whisper_hash = response.json().get(WhisperStatus.WHISPER_HASH)
+            output = self._extract_async(whisper_hash=whisper_hash)
+        else:
+            raise ExtractorError("Couldn't extract text from file")
+
+        try:
+            # Write output to a file
+            if output_file_path:
+                with open(output_file_path, "w", encoding="utf-8") as f:
+                    f.write(output)
+        except OSError as e:
+            logger.error(f"OS error while writing {output_file_path}: {e} ")
+            raise ExtractorError(str(e))
+        return output


### PR DESCRIPTION
## What

- Refactored existing sync implementation to support async calls of LLM whisperer
- MINOR: Removed `PLATFORM_API_KEY` since its unused - auth check was removed from LLM whisperer

## Why

- Recent changes in LLM whisperer to support async requests broke functionality in prompt studio for large files

## How

- Polling at fixed intervals to obtain the status (`/whisper-status`) and once the result is ready, the `/whisper-retrieve` API is invoked.

## Relevant Docs

- [LLM whisperer docs](https://docs.unstract.com/llm_whisperer/apis/llm_whisperer_apis_intro)

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

```
ADAPTER_LLMW_POLL_INTERVAL: Time in seconds to wait before polling LLMWhisperer's status API. Defaults to 30s
ADAPTER_LLMW_MAX_POLLS: Total number of times to poll the status API. Set to -1 to poll indefinitely. Defaults to -1
```

## Notes on Testing

- Tested the changes locally, used the debugger to ensure the correct code gets executed - reproduced the async behaviour by setting the `timeout` query param during extraction

## Screenshots
![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/7f645345-c3bd-49cc-a655-8a671ce6e6aa)
![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/30139297-519b-4d63-ab3a-1c3e07aadde9)



## Checklist

I have read and understood the [Contribution Guidelines]().
