### PR TITLE
fix: Resolve LLM whisperer poll envs as int, minor exc handling fix

### DIFF
--- a/src/unstract/adapters/utils.py
+++ b/src/unstract/adapters/utils.py
@@ -30,7 +30,7 @@ class AdapterUtils:
                 if message_key in err_json:
                     return str(err_json[message_key])
             elif err_response.headers["Content-Type"] == "text/plain":
-                return err.response.text()  # type: ignore
+                return err.response.text  # type: ignore
         return default_err
 
     @staticmethod

--- a/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
@@ -77,5 +77,5 @@ class WhispererDefaults:
     MEDIAN_FILTER_SIZE = 0
     GAUSSIAN_BLUR_RADIUS = 0.0
     FORCE_TEXT_PROCESSING = False
-    POLL_INTERVAL = os.getenv(WhispererEnv.POLL_INTERVAL, 30)
-    MAX_POLLS = os.getenv(WhispererEnv.MAX_POLLS, 30)
+    POLL_INTERVAL = int(os.getenv(WhispererEnv.POLL_INTERVAL, 30))
+    MAX_POLLS = int(os.getenv(WhispererEnv.MAX_POLLS, 30))

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -111,7 +111,7 @@ class LLMWhisperer(X2TextAdapter):
         except ConnectionError as e:
             logger.error(f"Adapter error: {e}")
             raise ExtractorError(
-                "Unable to connect to LLM Whisperer service, " "please check the URL"
+                "Unable to connect to LLM Whisperer service, please check the URL"
             )
         except Timeout as e:
             msg = "Request to LLM whisperer has timed out"


### PR DESCRIPTION
## What

- Resolved LLM whisperer's poll related envs as int - previously it was a string
- Minor error handling fix in obtaining the `response.text` from `RequestError`s

**NOTE: The version 0.12.1 was already bumped in https://github.com/Zipstack/unstract-adapters/pull/40 but not yet released. We can reuse the same version**

## Why

- Traceback for poll related type error (issue 1)
```
172.20.0.10 - - [25/Apr/2024:06:16:36 +0000] "POST /api/v1/unstract/org_HJqNgodUQsA99S3A/prompt-studio/index-document/7f7f863d-16d4-4684-808d-68fc5e489f3e HTTP/1.1" 500 112 "https://globe.unstract.com/zipstack/tools/7f7f863d-16d4-4684-808d-68fc5e489f3e" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"

TypeError: an integer is required (got type str)
    time.sleep(POLL_INTERVAL)
  File "/app/.venv/lib/python3.9/site-packages/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py", line 232, in _check_status_until_ready
    self._check_status_until_ready(
  File "/app/.venv/lib/python3.9/site-packages/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py", line 253, in _extract_async
    output = self._extract_async(whisper_hash=whisper_hash)
  File "/app/.venv/lib/python3.9/site-packages/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py", line 311, in process
    extracted_text = x2text_adapter_inst.process(
  File "/app/.venv/lib/python3.9/site-packages/unstract/sdk/index.py", line 248, in index_file
    doc_id: str = tool_index.index_file(
  File "/app/prompt_studio/prompt_studio_core/prompt_studio_helper.py", line 643, in dynamic_indexer
    doc_id = PromptStudioHelper.dynamic_indexer(
  File "/app/prompt_studio/prompt_studio_core/prompt_studio_helper.py", line 244, in index_document
    unique_id = PromptStudioHelper.index_document(
  File "/app/prompt_studio/prompt_studio_core/views.py", line 206, in index_document
    response = handler(request, *args, **kwargs)
  File "/app/.venv/lib/python3.9/site-packages/rest_framework/views.py", line 506, in dispatch
Traceback (most recent call last):

TypeError('an integer is required (got type str)')
```

- Traceback for exception handling issue (issues 2)
![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/b228fedd-c939-432c-b689-4d52760892ec)


## Related Issues or PRs

- #39 
- #40 

## Notes on Testing

- First issue was not reproducible locally - probably because its run in `DEBUG` mode and types are resolved correctly. Anyway in the expense of time - haven't explicitly tested this
- Second issue was observed with a 503 error from LLM whisperer which itself is related to memory usage and not easily reproducible


## Checklist

I have read and understood the [Contribution Guidelines]().
