### PR TITLE
fix: Exposed max retry for LLMs - Mistral, Vertex AI, Azure Open AI

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 
 import logging

--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.2"
+__version__ = "0.13.0"
 
 
 import logging

--- a/src/unstract/adapters/llm/anthropic/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/anthropic/src/static/json_schema.json
@@ -27,7 +27,7 @@
     },
     "max_retries": {
       "type": "integer",
-      "title": "Max retries",
+      "title": "Max Retries",
       "default": 3,
       "format": "number",
       "description": "Maximum number of retries"

--- a/src/unstract/adapters/llm/any_scale/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/any_scale/src/static/json_schema.json
@@ -26,7 +26,7 @@
     },
     "max_retries": {
       "type": "integer",
-      "title": "Max retries",
+      "title": "Max Retries",
       "default": 5,
       "description": "Maximum number of retries to make when a request fails."
     },

--- a/src/unstract/adapters/llm/azure_open_ai/src/azure_open_ai.py
+++ b/src/unstract/adapters/llm/azure_open_ai/src/azure_open_ai.py
@@ -15,7 +15,7 @@ class Constants:
     DEPLOYMENT_NAME = "deployment_name"
     API_KEY = "api_key"
     API_VERSION = "api_version"
-    MAX_RETIRES = "max_retries"
+    MAX_RETRIES = "max_retries"
     AZURE_ENDPONT = "azure_endpoint"
     API_TYPE = "azure"
     TIMEOUT = "timeout"
@@ -51,6 +51,9 @@ class AzureOpenAILLM(LLMAdapter):
         return schema
 
     def get_llm_instance(self) -> LLM:
+        max_retries = int(
+            self.config.get(Constants.MAX_RETRIES, LLMKeys.DEFAULT_MAX_RETRIES)
+        )
         try:
             llm: LLM = AzureOpenAI(
                 model=self.config.get(Constants.MODEL, Constants.DEFAULT_MODEL),
@@ -60,9 +63,10 @@ class AzureOpenAILLM(LLMAdapter):
                 azure_endpoint=str(self.config.get(Constants.AZURE_ENDPONT)),
                 api_type=Constants.API_TYPE,
                 temperature=0,
-                timeout=self.config.get(
-                    Constants.TIMEOUT, LLMKeys.DEFAULT_TIMEOUT
+                timeout=float(
+                    self.config.get(Constants.TIMEOUT, LLMKeys.DEFAULT_TIMEOUT)
                 ),
+                max_retries=max_retries,
             )
             return llm
         except Exception as e:

--- a/src/unstract/adapters/llm/azure_open_ai/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/azure_open_ai/src/static/json_schema.json
@@ -28,7 +28,7 @@
     },
     "max_retries": {
       "type": "integer",
-      "title": "Max retries",
+      "title": "Max Retries",
       "default": 5,
       "description": "Maximum number of retries to attempt when a request fails."
     },

--- a/src/unstract/adapters/llm/mistral/src/mistral.py
+++ b/src/unstract/adapters/llm/mistral/src/mistral.py
@@ -14,6 +14,7 @@ class Constants:
     MODEL = "model"
     API_KEY = "api_key"
     TIMEOUT = "timeout"
+    MAX_RETRIES = "max_retries"
 
 
 class MistralLLM(LLMAdapter):
@@ -45,14 +46,18 @@ class MistralLLM(LLMAdapter):
         return schema
 
     def get_llm_instance(self) -> LLM:
+        max_retries = int(
+            self.config.get(Constants.MAX_RETRIES, LLMKeys.DEFAULT_MAX_RETRIES)
+        )
         try:
             llm: LLM = MistralAI(
                 model=str(self.config.get(Constants.MODEL)),
                 api_key=str(self.config.get(Constants.API_KEY)),
                 temperature=0,
-                timeout=self.config.get(
-                    Constants.TIMEOUT, LLMKeys.DEFAULT_TIMEOUT
+                timeout=float(
+                    self.config.get(Constants.TIMEOUT, LLMKeys.DEFAULT_TIMEOUT)
                 ),
+                max_retries=max_retries,
             )
             return llm
         except Exception as e:

--- a/src/unstract/adapters/llm/mistral/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/mistral/src/static/json_schema.json
@@ -27,7 +27,7 @@
     },
     "max_retries": {
       "type": "integer",
-      "title": "Max retries",
+      "title": "Max Retries",
       "default": 5,
       "description": "Maximum number of retries to attempt when a request fails."
     },

--- a/src/unstract/adapters/llm/mistral/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/mistral/src/static/json_schema.json
@@ -25,6 +25,12 @@
       "format": "password",
       "description": "API Key for Mistral AI LLM"
     },
+    "max_retries": {
+      "type": "integer",
+      "title": "Max retries",
+      "default": 5,
+      "description": "Maximum number of retries to attempt when a request fails."
+    },
     "timeout": {
       "type": "number",
       "title": "Timeout",

--- a/src/unstract/adapters/llm/open_ai/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/open_ai/src/static/json_schema.json
@@ -40,7 +40,7 @@
     },
     "max_retries": {
       "type": "integer",
-      "title": "Max retries",
+      "title": "Max Retries",
       "default": 5,
       "description": "The maximum number of times to retry a request if it fails."
     },

--- a/src/unstract/adapters/llm/vertex_ai/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/vertex_ai/src/static/json_schema.json
@@ -31,6 +31,12 @@
       "title": "Project",
       "default": "",
       "description": "Provide the name of the deployment or project you defined for vectorai"
+    },
+    "max_retries": {
+      "type": "integer",
+      "title": "Max retries",
+      "default": 5,
+      "description": "Maximum number of retries to attempt when a request fails."
     }
   }
 }

--- a/src/unstract/adapters/llm/vertex_ai/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/vertex_ai/src/static/json_schema.json
@@ -34,7 +34,7 @@
     },
     "max_retries": {
       "type": "integer",
-      "title": "Max retries",
+      "title": "Max Retries",
       "default": 5,
       "description": "Maximum number of retries to attempt when a request fails."
     }

--- a/src/unstract/adapters/llm/vertex_ai/src/vertex_ai.py
+++ b/src/unstract/adapters/llm/vertex_ai/src/vertex_ai.py
@@ -7,6 +7,7 @@ from google.oauth2 import service_account
 from llama_index.core.llms import LLM
 from llama_index.llms.vertex import Vertex
 
+from unstract.adapters.llm.constants import LLMKeys
 from unstract.adapters.llm.helper import LLMHelper
 from unstract.adapters.llm.llm_adapter import LLMAdapter
 
@@ -15,6 +16,7 @@ class Constants:
     MODEL = "model"
     PROJECT = "project"
     JSON_CREDENTIALS = "json_credentials"
+    MAX_RETRIES = "max_retries"
 
 
 class VertexAILLM(LLMAdapter):
@@ -55,11 +57,15 @@ class VertexAILLM(LLMAdapter):
             scopes=["https://www.googleapis.com/auth/cloud-platform"],
         )
         credentials.refresh(google_requests.Request())
+        max_retries = int(
+            self.config.get(Constants.MAX_RETRIES, LLMKeys.DEFAULT_MAX_RETRIES)
+        )
         llm: LLM = Vertex(
             project=str(self.config.get(Constants.PROJECT)),
             model=str(self.config.get(Constants.MODEL)),
             credentials=credentials,
             temperature=0,
+            max_retries=max_retries,
             additional_kwargs={},
         )
         return llm


### PR DESCRIPTION
## What

- Bumped Adapter version to 0.13.0
- Added `max_retry` for LLMs - Mistral, VertexAI, Azure Open AI
- Minor changes to Azure Open AI - passed max_retry

## Why

- To allow retry to be performed by llama index


## Notes on Testing

- Minor json schema changes for max retries, checked in UI.
- Checked existing adadpter also


## Screenshots

![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/029e00b4-2e98-4fe3-bf54-9cdd72b35282)
![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/a9b68aa1-8cae-4fab-8b16-61945054b28d)

## Checklist

I have read and understood the [Contribution Guidelines]().
