### PR TITLE
[FIX] Llama parse filetype fixes

### DIFF
--- a/src/unstract/adapters/utils.py
+++ b/src/unstract/adapters/utils.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import filetype
 import magic
 from requests import Response
 from requests.exceptions import RequestException
@@ -50,3 +51,20 @@ class AdapterUtils:
             input_file_mime = magic.from_buffer(sample_contents, mime=True)
             input_file_obj.seek(0)
         return input_file_mime
+
+    @staticmethod
+    def guess_extention(input_file_path: str) -> str:
+        """Returns the extention of the file passed.
+
+        Args:
+            input_file_path (str): String holding the path
+
+        Returns:
+            str: File extention
+        """
+        input_file_extention = ""
+        with open(input_file_path, mode="rb") as file_obj:
+            sample_contents = file_obj.read(100)
+            file_type = filetype.guess(sample_contents)
+            input_file_extention = file_type.EXTENSION
+        return input_file_extention

--- a/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
+++ b/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 from typing import Any, Optional
 
 import filetype
@@ -11,10 +12,6 @@ from unstract.adapters.x2text.llama_parse.src.constants import LlamaParseConfig
 from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
 logger = logging.getLogger(__name__)
-
-
-class Constants:
-    INFILE = "INFILE"
 
 
 class LlamaParseAdapter(X2TextAdapter):
@@ -60,7 +57,8 @@ class LlamaParseAdapter(X2TextAdapter):
         )
 
         try:
-            if Constants.INFILE in input_file_path:
+            file_extension = pathlib.Path(input_file_path).suffix
+            if not file_extension:
                 try:
                     with open(input_file_path, mode="rb") as file_obj:
                         sample_contents = file_obj.read(100)

--- a/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
+++ b/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
@@ -58,13 +58,17 @@ class LlamaParseAdapter(X2TextAdapter):
         try:
             extention = input_file_path.rsplit(".", 1)[1]
             if not extention:
-                with open(input_file_path, mode="rb") as file_obj:
-                    sample_contents = file_obj.read(100)
-                    file_type = filetype.guess(sample_contents)
-                    input_file_path_copy = input_file_path
-                    input_file_path = ".".join(
-                        (input_file_path_copy, file_type.EXTENSION)
-                    )
+                try:
+                    with open(input_file_path, mode="rb") as file_obj:
+                        sample_contents = file_obj.read(100)
+                        file_type = filetype.guess(sample_contents)
+                        input_file_path_copy = input_file_path
+                        input_file_path = ".".join(
+                            (input_file_path_copy, file_type.EXTENSION)
+                        )
+                except OSError as os_err:
+                    logger.error("Exception raised while handling input file.")
+                    raise AdapterError(str(os_err))
 
             documents = parser.load_data(input_file_path)
 
@@ -78,7 +82,7 @@ class LlamaParseAdapter(X2TextAdapter):
             logger.error(
                 "Seems like an invalid API Key or possible internal errors: {exe}"
             )
-            raise AdapterError(exe)
+            raise AdapterError(str(exe))
 
         response_text = documents[0].text
         return response_text  # type: ignore

--- a/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
+++ b/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
@@ -13,6 +13,10 @@ from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 logger = logging.getLogger(__name__)
 
 
+class Constants:
+    INFILE = "INFILE"
+
+
 class LlamaParseAdapter(X2TextAdapter):
     def __init__(self, settings: dict[str, Any]):
         super().__init__("LlamaParse")
@@ -56,8 +60,7 @@ class LlamaParseAdapter(X2TextAdapter):
         )
 
         try:
-            extention = input_file_path.rsplit(".", 1)[1]
-            if not extention:
+            if Constants.INFILE in input_file_path:
                 try:
                     with open(input_file_path, mode="rb") as file_obj:
                         sample_contents = file_obj.read(100)

--- a/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
+++ b/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Any, Optional
 
+import filetype
 from httpx import ConnectError
 from llama_parse import LlamaParse
 
@@ -55,6 +56,16 @@ class LlamaParseAdapter(X2TextAdapter):
         )
 
         try:
+            extention = input_file_path.rsplit(".", 1)[1]
+            if not extention:
+                with open(input_file_path, mode="rb") as file_obj:
+                    sample_contents = file_obj.read(100)
+                    file_type = filetype.guess(sample_contents)
+                    input_file_path_copy = input_file_path
+                    input_file_path = ".".join(
+                        (input_file_path_copy, file_type.EXTENSION)
+                    )
+
             documents = parser.load_data(input_file_path)
 
         except ConnectError as connec_err:

--- a/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
+++ b/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
@@ -3,11 +3,11 @@ import os
 import pathlib
 from typing import Any, Optional
 
-import filetype
 from httpx import ConnectError
 from llama_parse import LlamaParse
 
 from unstract.adapters.exceptions import AdapterError
+from unstract.adapters.utils import AdapterUtils
 from unstract.adapters.x2text.llama_parse.src.constants import LlamaParseConfig
 from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
@@ -60,13 +60,11 @@ class LlamaParseAdapter(X2TextAdapter):
             file_extension = pathlib.Path(input_file_path).suffix
             if not file_extension:
                 try:
-                    with open(input_file_path, mode="rb") as file_obj:
-                        sample_contents = file_obj.read(100)
-                        file_type = filetype.guess(sample_contents)
-                        input_file_path_copy = input_file_path
-                        input_file_path = ".".join(
-                            (input_file_path_copy, file_type.EXTENSION)
-                        )
+                    input_file_extension = AdapterUtils.guess_extention(input_file_path)
+                    input_file_path_copy = input_file_path
+                    input_file_path = ".".join(
+                        (input_file_path_copy, input_file_extension)
+                    )
                 except OSError as os_err:
                     logger.error("Exception raised while handling input file.")
                     raise AdapterError(str(os_err))
@@ -86,7 +84,7 @@ class LlamaParseAdapter(X2TextAdapter):
             raise AdapterError(str(exe))
 
         response_text = documents[0].text
-        return response_text  # type: ignore
+        return response_text  # type:ignore
 
     def process(
         self,


### PR DESCRIPTION
## What
Fix for Llama parse adapter to pick files without extention.
...

## Why
Lllama parse library do not read the extention using any library. Rather is does from file name,
But during workflow executuon we send INFILE, which doesnt have extention.
...

## How
Added extention to file name when it is invoked from workflow.
...

## Relevant Docs

...
## Related Issues or PRs

...
## Dependencies Versions / Env Variables
Not applicable.
...

## Screenshots
![Screenshot from 2024-04-23 14-28-54](https://github.com/Zipstack/unstract-adapters/assets/115449948/0c216a2a-feb1-4a7a-8e50-8eab53082014)

![Screenshot from 2024-04-18 12-30-52](https://github.com/Zipstack/unstract-adapters/assets/115449948/934bae8c-88a4-46c5-9624-19a56910a000)


...

## Checklist

I have read and understood the [Contribution Guidelines]().
