### PR TITLE
Pinecone re-indexing and Postgres deletion of data in test-connection issue fixes

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.15.1"
+__version__ = "0.16.0"
 
 
 import logging

--- a/src/unstract/adapters/base.py
+++ b/src/unstract/adapters/base.py
@@ -1,15 +1,5 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Union
-
-from llama_index.core import MockEmbedding
-from llama_index.core.embeddings import BaseEmbedding
-from llama_index.core.llms import LLM, MockLLM
-from llama_index.core.vector_stores import SimpleVectorStore
-from llama_index.core.vector_stores.types import (
-    BasePydanticVectorStore,
-    VectorStore,
-)
 
 from unstract.adapters.enums import AdapterTypes
 
@@ -49,21 +39,6 @@ class Adapter(ABC):
     @abstractmethod
     def get_adapter_type() -> AdapterTypes:
         return ""
-
-    def get_llm_instance(self, llm_config: dict[str, Any]) -> LLM:
-        # Overriding implementations use llm_config
-        return MockLLM()
-
-    def get_vector_db_instance(
-        self, vector_db_config: dict[str, Any]
-    ) -> Union[BasePydanticVectorStore, VectorStore]:
-        # Overriding implementations use vector_db_config
-        return SimpleVectorStore()
-
-    def get_embedding_instance(
-        self, embed_config: dict[str, Any]
-    ) -> BaseEmbedding:
-        return MockEmbedding(embed_dim=1)
 
     @abstractmethod
     def test_connection(self) -> bool:

--- a/src/unstract/adapters/vectordb/constants.py
+++ b/src/unstract/adapters/vectordb/constants.py
@@ -2,5 +2,5 @@ class VectorDbConstants:
     VECTOR_DB_NAME = "collection_name"
     EMBEDDING_DIMENSION = "embedding_dimension"
     DEFAULT_VECTOR_DB_NAME = "unstract"
-    DEFAULT_EMBEDDING_SIZE = 1536
+    DEFAULT_EMBEDDING_SIZE = 1
     TEST_CONNECTION_EMBEDDING_SIZE = 1

--- a/src/unstract/adapters/vectordb/milvus/src/milvus.py
+++ b/src/unstract/adapters/vectordb/milvus/src/milvus.py
@@ -81,3 +81,7 @@ class Milvus(VectorDBAdapter):
         if self.client is not None:
             self.client.drop_collection(self.collection_name)
         return test_result
+
+    def close(self, **kwargs: Any) -> None:
+        if self.client:
+            self.client.close()

--- a/src/unstract/adapters/vectordb/pinecone/src/pinecone.py
+++ b/src/unstract/adapters/vectordb/pinecone/src/pinecone.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Any, Optional
 
+from llama_index.core.schema import BaseNode
 from llama_index.core.vector_stores.types import BasePydanticVectorStore
 from llama_index.vector_stores.pinecone import PineconeVectorStore
 from pinecone import NotFoundException
@@ -33,10 +34,11 @@ class Constants:
 
 class Pinecone(VectorDBAdapter):
     def __init__(self, settings: dict[str, Any]):
-        super().__init__("Pinecone")
-        self.config = settings
-        self.client: Optional[LLamaIndexPinecone] = None
-        self.collection_name: str = VectorDbConstants.DEFAULT_VECTOR_DB_NAME
+        self._config = settings
+        self._client: Optional[LLamaIndexPinecone] = None
+        self._collection_name: str = VectorDbConstants.DEFAULT_VECTOR_DB_NAME
+        self._vector_db_instance = self._get_vector_db_instance()
+        super().__init__("Pinecone", self._vector_db_instance)
 
     @staticmethod
     def get_id() -> str:
@@ -62,58 +64,57 @@ class Pinecone(VectorDBAdapter):
         return schema
 
     def get_vector_db_instance(self) -> BasePydanticVectorStore:
-        try:
-            self.client = LLamaIndexPinecone(
-                api_key=str(self.config.get(Constants.API_KEY))
-            )
-            collection_name = VectorDBHelper.get_collection_name(
-                self.config.get(VectorDbConstants.VECTOR_DB_NAME),
-                self.config.get(VectorDbConstants.EMBEDDING_DIMENSION),
-            )
-            self.collection_name = collection_name.replace("_", "-").lower()
-            dimension = self.config.get(
-                VectorDbConstants.EMBEDDING_DIMENSION,
-                VectorDbConstants.DEFAULT_EMBEDDING_SIZE,
-            )
+        return self._vector_db_instance
 
-            specification = self.config.get(Constants.SPECIFICATION)
-            if specification == Constants.SPEC_POD:
-                environment = self.config.get(Constants.ENVIRONMENT)
-                spec = PodSpec(
-                    environment=environment,
-                    replicas=Constants.DEFAULT_SPEC_COUNT_VALUE,
-                    shards=Constants.DEFAULT_SPEC_COUNT_VALUE,
-                    pods=Constants.DEFAULT_SPEC_COUNT_VALUE,
-                    pod_type=Constants.DEFAULT_POD_TYPE,
-                )
-            elif specification == Constants.SPEC_SERVERLESS:
-                cloud = self.config.get(Constants.CLOUD)
-                region = self.config.get(Constants.REGION)
-                spec = ServerlessSpec(cloud=cloud, region=region)
-            logger.info(f"Setting up Pinecone spec for {spec}")
-            try:
-                self.client.describe_index(name=self.collection_name)
-            except NotFoundException:
-                logger.info(
-                    f"Index:{self.collection_name} does not exist. Creating it."
-                )
-                self.client.create_index(
-                    name=self.collection_name,
-                    dimension=dimension,
-                    metric=Constants.METRIC,
-                    spec=spec,
-                )
-            vector_db: BasePydanticVectorStore = PineconeVectorStore(
-                index_name=self.collection_name,
-                api_key=str(self.config.get(Constants.API_KEY)),
-                environment=str(self.config.get(Constants.ENVIRONMENT)),
+    def _get_vector_db_instance(self) -> BasePydanticVectorStore:
+
+        self._client = LLamaIndexPinecone(
+            api_key=str(self._config.get(Constants.API_KEY))
+        )
+        collection_name = VectorDBHelper.get_collection_name(
+            self._config.get(VectorDbConstants.VECTOR_DB_NAME),
+            self._config.get(VectorDbConstants.EMBEDDING_DIMENSION),
+        )
+        self._collection_name = collection_name.replace("_", "-").lower()
+        dimension = self._config.get(
+            VectorDbConstants.EMBEDDING_DIMENSION,
+            VectorDbConstants.DEFAULT_EMBEDDING_SIZE,
+        )
+
+        specification = self._config.get(Constants.SPECIFICATION)
+        if specification == Constants.SPEC_POD:
+            environment = self._config.get(Constants.ENVIRONMENT)
+            spec = PodSpec(
+                environment=environment,
+                replicas=Constants.DEFAULT_SPEC_COUNT_VALUE,
+                shards=Constants.DEFAULT_SPEC_COUNT_VALUE,
+                pods=Constants.DEFAULT_SPEC_COUNT_VALUE,
+                pod_type=Constants.DEFAULT_POD_TYPE,
             )
-            return vector_db
-        except Exception as e:
-            raise AdapterError(str(e))
+        elif specification == Constants.SPEC_SERVERLESS:
+            cloud = self._config.get(Constants.CLOUD)
+            region = self._config.get(Constants.REGION)
+            spec = ServerlessSpec(cloud=cloud, region=region)
+        logger.info(f"Setting up Pinecone spec for {spec}")
+        try:
+            self._client.describe_index(name=self._collection_name)
+        except NotFoundException:
+            logger.info(f"Index:{self._collection_name} does not exist. Creating it.")
+            self._client.create_index(
+                name=self._collection_name,
+                dimension=dimension,
+                metric=Constants.METRIC,
+                spec=spec,
+            )
+        self.vector_db: BasePydanticVectorStore = PineconeVectorStore(
+            index_name=self._collection_name,
+            api_key=str(self._config.get(Constants.API_KEY)),
+            environment=str(self._config.get(Constants.ENVIRONMENT)),
+        )
+        return self.vector_db
 
     def test_connection(self) -> bool:
-        self.config[VectorDbConstants.EMBEDDING_DIMENSION] = (
+        self._config[VectorDbConstants.EMBEDDING_DIMENSION] = (
             VectorDbConstants.TEST_CONNECTION_EMBEDDING_SIZE
         )
         vector_db = self.get_vector_db_instance()
@@ -121,10 +122,43 @@ class Pinecone(VectorDBAdapter):
             vector_store=vector_db
         )
         # Delete the collection that was created for testing
-        if self.client:
-            self.client.delete_index(self.collection_name)
+        if self._client:
+            self._client.delete_index(self._collection_name)
         return test_result
 
     def close(self, **kwargs: Any) -> None:
         # Close connection is not defined for this client
         pass
+
+    def delete(self, ref_doc_id: str, **delete_kwargs: dict[Any, Any]) -> None:
+        specification = self._config.get(Constants.SPECIFICATION)
+        if specification == Constants.SPEC_SERVERLESS:
+            # To delete all records representing chunks of a single document,
+            # first list the record IDs based on their common ID prefix,
+            # and then delete the records by ID:
+            try:
+                index = self._client.Index(self._collection_name)  # type: ignore
+                # Get all record having the ref_doc_id and delete them
+                for ids in index.list(prefix=ref_doc_id):
+                    logger.info(ids)
+                    index.delete(ids=ids)
+            except Exception as e:
+                raise AdapterError(str(e))
+        elif specification == Constants.SPEC_POD:
+            if self.vector_db.environment == "gcp-starter":  # type: ignore
+                raise AdapterError(
+                    "Re-indexing is not supported on Starter indexes. "
+                    "Use Serverless or paid plan for Pod spec"
+                )
+            else:
+                super().delete(ref_doc_id=ref_doc_id, **delete_kwargs)
+
+    def add(
+        self,
+        ref_doc_id: str,
+        nodes: list[BaseNode],
+    ) -> list[str]:
+        for i, node in enumerate(nodes):
+            node_id = ref_doc_id + "-" + node.node_id
+            nodes[i].id_ = node_id
+        return self.vector_db.add(nodes=nodes)

--- a/src/unstract/adapters/vectordb/pinecone/src/pinecone.py
+++ b/src/unstract/adapters/vectordb/pinecone/src/pinecone.py
@@ -124,3 +124,7 @@ class Pinecone(VectorDBAdapter):
         if self.client:
             self.client.delete_index(self.collection_name)
         return test_result
+
+    def close(self, **kwargs: Any) -> None:
+        # Close connection is not defined for this client
+        pass

--- a/src/unstract/adapters/vectordb/postgres/src/postgres.py
+++ b/src/unstract/adapters/vectordb/postgres/src/postgres.py
@@ -109,3 +109,7 @@ class Postgres(VectorDBAdapter):
             self.client.commit()
 
         return test_result
+
+    def close(self, **kwargs: Any) -> None:
+        if self.client:
+            self.client.close()

--- a/src/unstract/adapters/vectordb/qdrant/src/qdrant.py
+++ b/src/unstract/adapters/vectordb/qdrant/src/qdrant.py
@@ -80,3 +80,7 @@ class Qdrant(VectorDBAdapter):
         if self.client is not None:
             self.client.delete_collection(self.collection_name)
         return test_result
+
+    def close(self, **kwargs: Any) -> None:
+        if self.client:
+            self.client.close(**kwargs)

--- a/src/unstract/adapters/vectordb/qdrant/src/qdrant.py
+++ b/src/unstract/adapters/vectordb/qdrant/src/qdrant.py
@@ -21,10 +21,11 @@ class Constants:
 
 class Qdrant(VectorDBAdapter):
     def __init__(self, settings: dict[str, Any]):
-        super().__init__("Qdrant")
-        self.config = settings
-        self.client: Optional[QdrantClient] = None
-        self.collection_name: str = VectorDbConstants.DEFAULT_VECTOR_DB_NAME
+        self._config = settings
+        self._client: Optional[QdrantClient] = None
+        self._collection_name: str = VectorDbConstants.DEFAULT_VECTOR_DB_NAME
+        self._vector_db_instance = self._get_vector_db_instance()
+        super().__init__("Qdrant", self._vector_db_instance)
 
     @staticmethod
     def get_id() -> str:
@@ -50,20 +51,23 @@ class Qdrant(VectorDBAdapter):
         return schema
 
     def get_vector_db_instance(self) -> BasePydanticVectorStore:
+        return self._vector_db_instance
+
+    def _get_vector_db_instance(self) -> BasePydanticVectorStore:
         try:
-            self.collection_name = VectorDBHelper.get_collection_name(
-                self.config.get(VectorDbConstants.VECTOR_DB_NAME),
-                self.config.get(VectorDbConstants.EMBEDDING_DIMENSION),
+            self._collection_name = VectorDBHelper.get_collection_name(
+                self._config.get(VectorDbConstants.VECTOR_DB_NAME),
+                self._config.get(VectorDbConstants.EMBEDDING_DIMENSION),
             )
-            url = self.config.get(Constants.URL)
-            api_key: Optional[str] = self.config.get(Constants.API_KEY, None)
+            url = self._config.get(Constants.URL)
+            api_key: Optional[str] = self._config.get(Constants.API_KEY, None)
             if api_key:
-                self.client = QdrantClient(url=url, api_key=api_key)
+                self._client = QdrantClient(url=url, api_key=api_key)
             else:
-                self.client = QdrantClient(url=url)
+                self._client = QdrantClient(url=url)
             vector_db: BasePydanticVectorStore = QdrantVectorStore(
-                collection_name=self.collection_name,
-                client=self.client,
+                collection_name=self._collection_name,
+                client=self._client,
                 url=url,
                 api_key=api_key,
             )
@@ -77,10 +81,10 @@ class Qdrant(VectorDBAdapter):
             vector_store=vector_db
         )
         # Delete the collection that was created for testing
-        if self.client is not None:
-            self.client.delete_collection(self.collection_name)
+        if self._client is not None:
+            self._client.delete_collection(self._collection_name)
         return test_result
 
     def close(self, **kwargs: Any) -> None:
-        if self.client:
-            self.client.close(**kwargs)
+        if self._client:
+            self._client.close(**kwargs)

--- a/src/unstract/adapters/vectordb/supabase/src/supabase.py
+++ b/src/unstract/adapters/vectordb/supabase/src/supabase.py
@@ -95,3 +95,7 @@ class Supabase(VectorDBAdapter):
         if self.client is not None:
             self.client.delete_collection(self.collection_name)
         return test_result
+
+    def close(self, **kwargs: Any) -> None:
+        if self.client:
+            self.client.close()

--- a/src/unstract/adapters/vectordb/vectordb_adapter.py
+++ b/src/unstract/adapters/vectordb/vectordb_adapter.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from typing import Any, Union
 
+from llama_index.core.schema import BaseNode
 from llama_index.core.vector_stores import SimpleVectorStore
 from llama_index.core.vector_stores.types import BasePydanticVectorStore, VectorStore
 
@@ -9,9 +10,16 @@ from unstract.adapters.enums import AdapterTypes
 
 
 class VectorDBAdapter(Adapter, ABC):
-    def __init__(self, name: str):
+    def __init__(
+        self,
+        name: str,
+        vector_db_instance: Union[VectorStore, BasePydanticVectorStore],
+    ):
         super().__init__(name)
         self.name = name
+        self._vector_db_instance: Union[VectorStore, BasePydanticVectorStore] = (
+            vector_db_instance
+        )
 
     @staticmethod
     def get_id() -> str:
@@ -59,3 +67,18 @@ class VectorDBAdapter(Adapter, ABC):
         # Overriding implementations will have the corresponding
         # library methods invoked
         pass
+
+    def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
+        """Delete the specified docs.
+
+        Returns:
+            None
+        """
+        # Overriding implementations will have the corresponding
+        # library methods invoked
+        self._vector_db_instance.delete(
+            ref_doc_id=ref_doc_id, delete_kwargs=delete_kwargs
+        )
+
+    def add(self, ref_doc_id: str, nodes: list[BaseNode]) -> list[str]:
+        return self._vector_db_instance.add(nodes=nodes)

--- a/src/unstract/adapters/vectordb/vectordb_adapter.py
+++ b/src/unstract/adapters/vectordb/vectordb_adapter.py
@@ -2,10 +2,7 @@ from abc import ABC
 from typing import Any, Union
 
 from llama_index.core.vector_stores import SimpleVectorStore
-from llama_index.core.vector_stores.types import (
-    BasePydanticVectorStore,
-    VectorStore,
-)
+from llama_index.core.vector_stores.types import BasePydanticVectorStore, VectorStore
 
 from unstract.adapters.base import Adapter
 from unstract.adapters.enums import AdapterTypes
@@ -52,3 +49,13 @@ class VectorDBAdapter(Adapter, ABC):
             Raises exceptions for any error
         """
         return SimpleVectorStore()
+
+    def close(self, **kwargs: Any) -> None:
+        """Closes the client connection.
+
+        Returns:
+            None
+        """
+        # Overriding implementations will have the corresponding
+        # library methods invoked
+        pass


### PR DESCRIPTION
## What

1. Refactoring Adapters to accomodate pinecone Serverless issues
2. Test connection deletes off existing tables under schema unstract

## Why

Serverless Pinecone is unusable for re-indexing at the moment
There are however some limitations:

Serverless - During re-indexing, if the existing indexed records were indexed using chunk size > 0 then they will not be deleted. Silently ignored
Pod-based (paid) - All is well
Pod-based (Free tier/Starter) - Re-indexing is not supported as with latest Pinecone, we will need exact id to delete the record for the starter plan (edited) 

## How

- Using specified implementation for adding and deleting vectors
- Use specified schema for test connection and delete that  alone

## Relevant Docs

-

## Related Issues or PRs

- https://zipstack.atlassian.net/browse/UN-1244
- https://zipstack.atlassian.net/browse/UN-1278

## Dependencies Versions / Env Variables

-

## Notes on Testing

- Pertaining to the above scope of limitations, testing was done

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
