### PR TITLE
feat: Added 2 params to LLM whisperer

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.16.0"
+__version__ = "0.17.0"
 
 
 import logging

--- a/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
@@ -57,6 +57,8 @@ class WhispererConfig:
     MEDIAN_FILTER_SIZE = "median_filter_size"
     GAUSSIAN_BLUR_RADIUS = "gaussian_blur_radius"
     FORCE_TEXT_PROCESSING = "force_text_processing"
+    LINE_SPLITTER_TOLERANCE = "line_splitter_tolerance"
+    HORIZONTAL_STRETCH_FACTOR = "horizontal_stretch_factor"
 
 
 class WhisperStatus:
@@ -77,5 +79,7 @@ class WhispererDefaults:
     MEDIAN_FILTER_SIZE = 0
     GAUSSIAN_BLUR_RADIUS = 0.0
     FORCE_TEXT_PROCESSING = False
+    LINE_SPLITTER_TOLERANCE = 0.75
+    HORIZONTAL_STRETCH_FACTOR = 1.0
     POLL_INTERVAL = int(os.getenv(WhispererEnv.POLL_INTERVAL, 30))
     MAX_POLLS = int(os.getenv(WhispererEnv.MAX_POLLS, 30))

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -145,6 +145,14 @@ class LLMWhisperer(X2TextAdapter):
                 WhispererConfig.FORCE_TEXT_PROCESSING,
                 WhispererDefaults.FORCE_TEXT_PROCESSING,
             ),
+            WhispererConfig.LINE_SPLITTER_TOLERANCE: self.config.get(
+                WhispererConfig.LINE_SPLITTER_TOLERANCE,
+                WhispererDefaults.LINE_SPLITTER_TOLERANCE,
+            ),
+            WhispererConfig.HORIZONTAL_STRETCH_FACTOR: self.config.get(
+                WhispererConfig.HORIZONTAL_STRETCH_FACTOR,
+                WhispererDefaults.HORIZONTAL_STRETCH_FACTOR,
+            ),
         }
         if not params[WhispererConfig.FORCE_TEXT_PROCESSING]:
             params.update(

--- a/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -64,6 +64,18 @@
       "title": "Gaussian Blur Radius",
       "default": 0.0,
       "description": "The radius of the gaussian blur to use for pre-processing the image during OCR based extraction. Useful to eliminate noise from the image. Default is 0.0 if the value is not explicitly set."
+    },
+    "line_splitter_tolerance": {
+      "type": "number",
+      "title": "Line Splitter Tolerance",
+      "default": 0.75,
+      "description": "Reduce this value to split lines less often, increase to split lines more often. Useful when PDFs have multi column layout with text in each column that is not aligned."
+    },
+    "horizontal_stretch_factor": {
+      "type": "number",
+      "title": "Horizontal Stretch Factor",
+      "default": 1.0,
+      "description": "Increase this value to stretch text horizontally, decrease to compress text horizontally. Useful when multi column text merge with each other."
     }
   },
   "if": {


### PR DESCRIPTION

## What

-  Added `line_splitter_tolerance` and `horizontal_stretch_factor` to LLM Whisperer
- Bumped adapter version to 0.17.0

## Why

- Recent enhancements in LLM whisperer

## How

...

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

- Able to add / edit adapters and also run prompts - works with existing too because of defaults

## Screenshots

![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/29cd580d-cb21-4875-bde5-00c29cb2b6a8)
![image](https://github.com/Zipstack/unstract-adapters/assets/117059509/627b3a6f-ea96-445a-be9e-481159b0bf14)

## Checklist

I have read and understood the [Contribution Guidelines]().
