### PR TITLE
Added changes for exposing whisper hash

### DIFF
--- a/src/unstract/adapters/x2text/constants.py
+++ b/src/unstract/adapters/x2text/constants.py
@@ -2,3 +2,5 @@ class X2TextConstants:
     PLATFORM_SERVICE_API_KEY = "PLATFORM_SERVICE_API_KEY"
     X2TEXT_HOST = "X2TEXT_HOST"
     X2TEXT_PORT = "X2TEXT_PORT"
+    EXTRACTED_TEXT = "extracted_text"
+    WHISPER_HASH = "whisper-hash"

--- a/src/unstract/adapters/x2text/constants.py
+++ b/src/unstract/adapters/x2text/constants.py
@@ -2,5 +2,6 @@ class X2TextConstants:
     PLATFORM_SERVICE_API_KEY = "PLATFORM_SERVICE_API_KEY"
     X2TEXT_HOST = "X2TEXT_HOST"
     X2TEXT_PORT = "X2TEXT_PORT"
+    ENABLE_HIGHLIGHT = "enable_highlight"
     EXTRACTED_TEXT = "extracted_text"
     WHISPER_HASH = "whisper-hash"

--- a/src/unstract/adapters/x2text/dto.py
+++ b/src/unstract/adapters/x2text/dto.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from typing import Union
+
+
+@dataclass
+class TextExtractionMetaData:
+    whisper_hash: str
+
+
+@dataclass
+class TextExtractionResult:
+    extracted_text: str
+    extraction_metadata: Union[TextExtractionMetaData, None]

--- a/src/unstract/adapters/x2text/dto.py
+++ b/src/unstract/adapters/x2text/dto.py
@@ -3,11 +3,11 @@ from typing import Union
 
 
 @dataclass
-class TextExtractionMetaData:
+class TextExtractionMetadata:
     whisper_hash: str
 
 
 @dataclass
 class TextExtractionResult:
     extracted_text: str
-    extraction_metadata: Union[TextExtractionMetaData, None]
+    extraction_metadata: Union[TextExtractionMetadata, None]

--- a/src/unstract/adapters/x2text/dto.py
+++ b/src/unstract/adapters/x2text/dto.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Union
+from typing import Optional
 
 
 @dataclass
@@ -10,4 +10,4 @@ class TextExtractionMetadata:
 @dataclass
 class TextExtractionResult:
     extracted_text: str
-    extraction_metadata: Union[TextExtractionMetadata, None]
+    extraction_metadata: Optional[TextExtractionMetadata] = None

--- a/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
+++ b/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
@@ -8,6 +8,7 @@ from llama_parse import LlamaParse
 
 from unstract.adapters.exceptions import AdapterError
 from unstract.adapters.utils import AdapterUtils
+from unstract.adapters.x2text.constants import X2TextConstants
 from unstract.adapters.x2text.llama_parse.src.constants import LlamaParseConfig
 from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
@@ -91,13 +92,16 @@ class LlamaParseAdapter(X2TextAdapter):
         input_file_path: str,
         output_file_path: Optional[str] = None,
         **kwargs: dict[Any, Any],
-    ) -> str:
+    ) -> dict[str, Any]:
 
         response_text = self._call_parser(input_file_path=input_file_path)
         if output_file_path:
             with open(output_file_path, "w", encoding="utf-8") as f:
                 f.write(response_text)
-        return response_text
+
+        output = {}
+        output[X2TextConstants.EXTRACTED_TEXT] = response_text
+        return output
 
     def test_connection(self) -> bool:
         self._call_parser(

--- a/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
+++ b/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
@@ -99,9 +99,7 @@ class LlamaParseAdapter(X2TextAdapter):
             with open(output_file_path, "w", encoding="utf-8") as f:
                 f.write(response_text)
 
-        return TextExtractionResult(
-            extracted_text=response_text, extraction_metadata=None
-        )
+        return TextExtractionResult(extracted_text=response_text)
 
     def test_connection(self) -> bool:
         self._call_parser(

--- a/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
+++ b/src/unstract/adapters/x2text/llama_parse/src/llama_parse.py
@@ -8,7 +8,7 @@ from llama_parse import LlamaParse
 
 from unstract.adapters.exceptions import AdapterError
 from unstract.adapters.utils import AdapterUtils
-from unstract.adapters.x2text.constants import X2TextConstants
+from unstract.adapters.x2text.dto import TextExtractionResult
 from unstract.adapters.x2text.llama_parse.src.constants import LlamaParseConfig
 from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
@@ -92,16 +92,16 @@ class LlamaParseAdapter(X2TextAdapter):
         input_file_path: str,
         output_file_path: Optional[str] = None,
         **kwargs: dict[Any, Any],
-    ) -> dict[str, Any]:
+    ) -> TextExtractionResult:
 
         response_text = self._call_parser(input_file_path=input_file_path)
         if output_file_path:
             with open(output_file_path, "w", encoding="utf-8") as f:
                 f.write(response_text)
 
-        output = {}
-        output[X2TextConstants.EXTRACTED_TEXT] = response_text
-        return output
+        return TextExtractionResult(
+            extracted_text=response_text, extraction_metadata=None
+        )
 
     def test_connection(self) -> bool:
         self._call_parser(

--- a/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
@@ -59,6 +59,7 @@ class WhispererConfig:
     FORCE_TEXT_PROCESSING = "force_text_processing"
     LINE_SPLITTER_TOLERANCE = "line_splitter_tolerance"
     HORIZONTAL_STRETCH_FACTOR = "horizontal_stretch_factor"
+    STORE_METADATA_FOR_HIGHLIGHTING = "store_metadata_for_highlighting"
 
 
 class WhisperStatus:

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -126,7 +126,7 @@ class LLMWhisperer(X2TextAdapter):
             raise ExtractorError(msg)
         return response
 
-    def _get_whisper_params(self) -> dict[str, Any]:
+    def _get_whisper_params(self, enable_highlight: bool = False) -> dict[str, Any]:
         """Gets query params meant for /whisper endpoint.
 
         The params is filled based on the configuration passed.
@@ -166,6 +166,11 @@ class LLMWhisperer(X2TextAdapter):
                         WhispererDefaults.GAUSSIAN_BLUR_RADIUS,
                     ),
                 }
+            )
+
+        if enable_highlight:
+            params.update(
+                {WhispererConfig.STORE_METADATA_FOR_HIGHLIGHTING: enable_highlight}
             )
         return params
 
@@ -267,10 +272,12 @@ class LLMWhisperer(X2TextAdapter):
                 f"{retrieve_response.status_code} - {retrieve_response.text}"
             )
 
-    def _send_whisper_request(self, input_file_path: str) -> requests.Response:
+    def _send_whisper_request(
+        self, input_file_path: str, enable_highlight: bool = False
+    ) -> requests.Response:
         headers = self._get_request_headers()
         headers["Content-Type"] = "application/octet-stream"
-        params = self._get_whisper_params()
+        params = self._get_whisper_params(enable_highlight)
 
         response: requests.Response
         try:
@@ -349,7 +356,7 @@ class LLMWhisperer(X2TextAdapter):
         """
         output = {}
 
-        response: requests.Response = self._send_whisper_request(input_file_path)
+        response: requests.Response = self._send_whisper_request(input_file_path, True)
         output["extracted_text"] = self._process_extract_text_from_response(
             output_file_path, response
         )

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -339,7 +339,7 @@ class LLMWhisperer(X2TextAdapter):
         output = {}
 
         response: requests.Response = self._send_whisper_request(
-            input_file_path, bool(kwargs.get("enable_highlight", False))
+            input_file_path, bool(kwargs.get(X2TextConstants.ENABLE_HIGHLIGHT, False))
         )
 
         output[X2TextConstants.EXTRACTED_TEXT] = self._extract_text_from_response(

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -10,7 +10,7 @@ from requests.exceptions import ConnectionError, HTTPError, Timeout
 from unstract.adapters.exceptions import ExtractorError
 from unstract.adapters.utils import AdapterUtils
 from unstract.adapters.x2text.constants import X2TextConstants
-from unstract.adapters.x2text.dto import TextExtractionMetaData, TextExtractionResult
+from unstract.adapters.x2text.dto import TextExtractionMetadata, TextExtractionResult
 from unstract.adapters.x2text.llm_whisperer.src.constants import (
     HTTPMethod,
     OutputModes,
@@ -341,7 +341,7 @@ class LLMWhisperer(X2TextAdapter):
             input_file_path, bool(kwargs.get(X2TextConstants.ENABLE_HIGHLIGHT, False))
         )
 
-        metadata = TextExtractionMetaData(
+        metadata = TextExtractionMetadata(
             whisper_hash=response.headers.get(X2TextConstants.WHISPER_HASH, "")
         )
 

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -337,6 +337,16 @@ class LLMWhisperer(X2TextAdapter):
         output_file_path: Optional[str] = None,
         **kwargs: dict[Any, Any],
     ) -> dict[str, str]:
+        """Used to extract text from documents.
+
+        Args:
+            input_file_path (str): Path to file that needs to be extracted
+            output_file_path (Optional[str], optional): File path to write
+                extracted text into, if None doesn't write to a file.
+                Defaults to None.
+        Returns:
+            dict[str, str]: extrcted text, whisper_hash
+        """
         output = {}
 
         response: requests.Response = self._send_whisper_request(input_file_path)

--- a/src/unstract/adapters/x2text/unstructured_community/src/unstructured_community.py
+++ b/src/unstract/adapters/x2text/unstructured_community/src/unstructured_community.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import Any, Optional
 
-from unstract.adapters.x2text.constants import X2TextConstants
+from unstract.adapters.x2text.dto import TextExtractionResult
 from unstract.adapters.x2text.helper import UnstructuredHelper
 from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
@@ -42,14 +42,14 @@ class UnstructuredCommunity(X2TextAdapter):
         input_file_path: str,
         output_file_path: Optional[str] = None,
         **kwargs: dict[Any, Any],
-    ) -> dict[str, Any]:
+    ) -> TextExtractionResult:
         extracted_text: str = UnstructuredHelper.process_document(
             self.config, input_file_path, output_file_path
         )
 
-        output = {}
-        output[X2TextConstants.EXTRACTED_TEXT] = extracted_text
-        return output
+        return TextExtractionResult(
+            extracted_text=extracted_text, extraction_metadata=None
+        )
 
     def test_connection(self) -> bool:
         result: bool = UnstructuredHelper.test_server_connection(self.config)

--- a/src/unstract/adapters/x2text/unstructured_community/src/unstructured_community.py
+++ b/src/unstract/adapters/x2text/unstructured_community/src/unstructured_community.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Any, Optional
 
+from unstract.adapters.x2text.constants import X2TextConstants
 from unstract.adapters.x2text.helper import UnstructuredHelper
 from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
@@ -41,10 +42,13 @@ class UnstructuredCommunity(X2TextAdapter):
         input_file_path: str,
         output_file_path: Optional[str] = None,
         **kwargs: dict[Any, Any],
-    ) -> str:
-        output: str = UnstructuredHelper.process_document(
+    ) -> dict[str, Any]:
+        extracted_text: str = UnstructuredHelper.process_document(
             self.config, input_file_path, output_file_path
         )
+
+        output = {}
+        output[X2TextConstants.EXTRACTED_TEXT] = extracted_text
         return output
 
     def test_connection(self) -> bool:

--- a/src/unstract/adapters/x2text/unstructured_community/src/unstructured_community.py
+++ b/src/unstract/adapters/x2text/unstructured_community/src/unstructured_community.py
@@ -47,9 +47,7 @@ class UnstructuredCommunity(X2TextAdapter):
             self.config, input_file_path, output_file_path
         )
 
-        return TextExtractionResult(
-            extracted_text=extracted_text, extraction_metadata=None
-        )
+        return TextExtractionResult(extracted_text=extracted_text)
 
     def test_connection(self) -> bool:
         result: bool = UnstructuredHelper.test_server_connection(self.config)

--- a/src/unstract/adapters/x2text/unstructured_enterprise/src/unstructured_enterprise.py
+++ b/src/unstract/adapters/x2text/unstructured_enterprise/src/unstructured_enterprise.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import Any, Optional
 
-from unstract.adapters.x2text.constants import X2TextConstants
+from unstract.adapters.x2text.dto import TextExtractionResult
 from unstract.adapters.x2text.helper import UnstructuredHelper
 from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
@@ -42,13 +42,14 @@ class UnstructuredEnterprise(X2TextAdapter):
         input_file_path: str,
         output_file_path: Optional[str] = None,
         **kwargs: dict[str, Any],
-    ) -> dict[str, Any]:
+    ) -> TextExtractionResult:
         extracted_text: str = UnstructuredHelper.process_document(
             self.config, input_file_path, output_file_path
         )
-        output = {}
-        output[X2TextConstants.EXTRACTED_TEXT] = extracted_text
-        return output
+
+        return TextExtractionResult(
+            extracted_text=extracted_text, extraction_metadata=None
+        )
 
     def test_connection(self) -> bool:
         result: bool = UnstructuredHelper.test_server_connection(self.config)

--- a/src/unstract/adapters/x2text/unstructured_enterprise/src/unstructured_enterprise.py
+++ b/src/unstract/adapters/x2text/unstructured_enterprise/src/unstructured_enterprise.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Any, Optional
 
+from unstract.adapters.x2text.constants import X2TextConstants
 from unstract.adapters.x2text.helper import UnstructuredHelper
 from unstract.adapters.x2text.x2text_adapter import X2TextAdapter
 
@@ -40,11 +41,13 @@ class UnstructuredEnterprise(X2TextAdapter):
         self,
         input_file_path: str,
         output_file_path: Optional[str] = None,
-        **kwargs: dict[Any, Any],
-    ) -> str:
-        output: str = UnstructuredHelper.process_document(
+        **kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        extracted_text: str = UnstructuredHelper.process_document(
             self.config, input_file_path, output_file_path
         )
+        output = {}
+        output[X2TextConstants.EXTRACTED_TEXT] = extracted_text
         return output
 
     def test_connection(self) -> bool:

--- a/src/unstract/adapters/x2text/unstructured_enterprise/src/unstructured_enterprise.py
+++ b/src/unstract/adapters/x2text/unstructured_enterprise/src/unstructured_enterprise.py
@@ -47,9 +47,7 @@ class UnstructuredEnterprise(X2TextAdapter):
             self.config, input_file_path, output_file_path
         )
 
-        return TextExtractionResult(
-            extracted_text=extracted_text, extraction_metadata=None
-        )
+        return TextExtractionResult(extracted_text=extracted_text)
 
     def test_connection(self) -> bool:
         result: bool = UnstructuredHelper.test_server_connection(self.config)

--- a/src/unstract/adapters/x2text/x2text_adapter.py
+++ b/src/unstract/adapters/x2text/x2text_adapter.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 
 from unstract.adapters.base import Adapter
 from unstract.adapters.enums import AdapterTypes
+from unstract.adapters.x2text.constants import X2TextConstants
 
 
 class X2TextAdapter(Adapter, ABC):
@@ -42,6 +43,10 @@ class X2TextAdapter(Adapter, ABC):
         input_file_path: str,
         output_file_path: Optional[str] = None,
         **kwargs: dict[Any, Any],
-    ) -> str:
+    ) -> dict[str, Any]:
         # Overriding methods will have the actual implementation
-        return ""
+        output = {}
+        # The below is mandatory field in all actual concrete implemenataions
+        output[X2TextConstants.EXTRACTED_TEXT] = "extracted_text"
+        # implementer can always add additional data specific to their implementations
+        return output

--- a/src/unstract/adapters/x2text/x2text_adapter.py
+++ b/src/unstract/adapters/x2text/x2text_adapter.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 
 from unstract.adapters.base import Adapter
 from unstract.adapters.enums import AdapterTypes
-from unstract.adapters.x2text.constants import X2TextConstants
+from unstract.adapters.x2text.dto import TextExtractionResult
 
 
 class X2TextAdapter(Adapter, ABC):
@@ -43,10 +43,8 @@ class X2TextAdapter(Adapter, ABC):
         input_file_path: str,
         output_file_path: Optional[str] = None,
         **kwargs: dict[Any, Any],
-    ) -> dict[str, Any]:
-        # Overriding methods will have the actual implementation
-        output = {}
-        # The below is mandatory field in all actual concrete implemenataions
-        output[X2TextConstants.EXTRACTED_TEXT] = "extracted_text"
-        # implementer can always add additional data specific to their implementations
-        return output
+    ) -> TextExtractionResult:
+
+        return TextExtractionResult(
+            extracted_text="extracted text", extraction_metadata=None
+        )


### PR DESCRIPTION
## What

Updated the return type of process methods in x2text adapters.

## Why

Require whisper hash in upstream (SDK, Unstract)

## How

returns dictionary containing extracted text and whsiper_hash

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
