### PR TITLE
[FIX] Encoding Postgres Connection URL

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.19.0"
+__version__ = "0.19.1"
 
 
 import logging

--- a/src/unstract/adapters/llm/ollama/src/ollama.py
+++ b/src/unstract/adapters/llm/ollama/src/ollama.py
@@ -62,6 +62,7 @@ class OllamaLLM(LLMAdapter):
                 ),
                 json_mode=False,
                 context_window=int(self.config.get(Constants.CONTEXT_WINDOW, 3900)),
+                temperature=0.01,
             )
             return llm
 

--- a/src/unstract/adapters/vectordb/postgres/src/postgres.py
+++ b/src/unstract/adapters/vectordb/postgres/src/postgres.py
@@ -59,7 +59,7 @@ class Postgres(VectorDBAdapter):
 
     def _get_vector_db_instance(self) -> BasePydanticVectorStore:
         try:
-            encrypted_password = urllib.parse.quote_plus(
+            encoded_password = urllib.parse.quote_plus(
                 str(self._config.get(Constants.PASSWORD))
             )
             self._collection_name = VectorDBHelper.get_collection_name(
@@ -78,7 +78,7 @@ class Postgres(VectorDBAdapter):
                 database=self._config.get(Constants.DATABASE),
                 schema_name=self._schema_name,
                 host=self._config.get(Constants.HOST),
-                password=encrypted_password,
+                password=encoded_password,
                 port=str(self._config.get(Constants.PORT)),
                 user=self._config.get(Constants.USER),
                 table_name=self._collection_name,

--- a/src/unstract/adapters/vectordb/postgres/src/postgres.py
+++ b/src/unstract/adapters/vectordb/postgres/src/postgres.py
@@ -1,4 +1,5 @@
 import os
+import urllib.parse
 from typing import Any, Optional
 
 import psycopg2
@@ -58,6 +59,9 @@ class Postgres(VectorDBAdapter):
 
     def _get_vector_db_instance(self) -> BasePydanticVectorStore:
         try:
+            encrypted_password = urllib.parse.quote_plus(
+                str(self._config.get(Constants.PASSWORD))
+            )
             self._collection_name = VectorDBHelper.get_collection_name(
                 self._config.get(VectorDbConstants.VECTOR_DB_NAME),
                 self._config.get(VectorDbConstants.EMBEDDING_DIMENSION),
@@ -74,7 +78,7 @@ class Postgres(VectorDBAdapter):
                 database=self._config.get(Constants.DATABASE),
                 schema_name=self._schema_name,
                 host=self._config.get(Constants.HOST),
-                password=self._config.get(Constants.PASSWORD),
+                password=encrypted_password,
                 port=str(self._config.get(Constants.PORT)),
                 user=self._config.get(Constants.USER),
                 table_name=self._collection_name,

--- a/src/unstract/adapters/vectordb/postgres/src/postgres.py
+++ b/src/unstract/adapters/vectordb/postgres/src/postgres.py
@@ -1,5 +1,5 @@
 import os
-import urllib.parse
+from urllib.parse import quote_plus
 from typing import Any, Optional
 
 import psycopg2

--- a/src/unstract/adapters/vectordb/postgres/src/postgres.py
+++ b/src/unstract/adapters/vectordb/postgres/src/postgres.py
@@ -59,8 +59,9 @@ class Postgres(VectorDBAdapter):
 
     def _get_vector_db_instance(self) -> BasePydanticVectorStore:
         try:
-            encoded_password = urllib.parse.quote_plus(
-                str(self._config.get(Constants.PASSWORD))
+            encoded_password = quote_plus(
+                str(self._config.get(Constants.PASSWORD)
+            )
             dimension = self._config.get(
                 VectorDbConstants.EMBEDDING_DIMENSION,
                 VectorDbConstants.DEFAULT_EMBEDDING_SIZE,

--- a/src/unstract/adapters/vectordb/supabase/src/supabase.py
+++ b/src/unstract/adapters/vectordb/supabase/src/supabase.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any, Optional
+import urllib.parse
 
 from llama_index.core.vector_stores.types import VectorStore
 from llama_index.vector_stores.supabase import SupabaseVectorStore
@@ -65,12 +66,15 @@ class Supabase(VectorDBAdapter):
             )
             user = str(self._config.get(Constants.USER))
             password = str(self._config.get(Constants.PASSWORD))
+            encoded_password = urllib.parse.quote_plus(
+                str(password)
+            )
             host = str(self._config.get(Constants.HOST))
             port = str(self._config.get(Constants.PORT))
             db_name = str(self._config.get(Constants.DATABASE))
 
             postgres_connection_string = (
-                f"postgresql://{user}:{password}@{host}:{port}/{db_name}"
+                f"postgresql://{user}:{encoded_password}@{host}:{port}/{db_name}"
             )
             dimension = self._config.get(
                 VectorDbConstants.EMBEDDING_DIMENSION,

--- a/src/unstract/adapters/vectordb/supabase/src/supabase.py
+++ b/src/unstract/adapters/vectordb/supabase/src/supabase.py
@@ -1,7 +1,6 @@
 import os
 from typing import Any, Optional
-import urllib.parse
-
+from urllib.parse import quote_plus
 from llama_index.core.vector_stores.types import VectorStore
 from llama_index.vector_stores.supabase import SupabaseVectorStore
 from vecs import Client
@@ -71,7 +70,7 @@ class Supabase(VectorDBAdapter):
             )
             user = str(self._config.get(Constants.USER))
             password = str(self._config.get(Constants.PASSWORD))
-            encoded_password = urllib.parse.quote_plus(
+            encoded_password = quote_plus(
                 str(password)
             )
             host = str(self._config.get(Constants.HOST))


### PR DESCRIPTION
## What
1. Encoding password in the connection URL
2. Made changes in the temperature of Ollama adapter
...

## Why
Passwords having special characters and @ symbol throws error in the connection string.
...

## How
Encoding using urllib.parse at the creation of connection URL.
...

## Relevant Docs
https://docs.sqlalchemy.org/en/20/core/engines.html#escaping-special-characters-such-as-signs-in-passwords
...

## Related Issues or PRs
Not applicable

...

## Dependencies Versions / Env Variables
Not applicable

...

## Notes on Testing
Tested by adding a local postrgres container with password containing `@`
...

## Screenshots
![Screenshot from 2024-06-20 15-54-59](https://github.com/Zipstack/unstract-adapters/assets/115449948/54c4f5e7-f456-4dab-b6aa-894836bc9b8f)

...

## Checklist

I have read and understood the [Contribution Guidelines]().
