### PR TITLE
Add Milvus support

### DIFF
--- a/src/unstract/adapters/vectordb/constants.py
+++ b/src/unstract/adapters/vectordb/constants.py
@@ -2,5 +2,4 @@ class VectorDbConstants:
     VECTOR_DB_NAME = "collection_name"
     EMBEDDING_DIMENSION = "embedding_dimension"
     DEFAULT_VECTOR_DB_NAME = "unstract"
-    DEFAULT_EMBEDDING_SIZE = 1
-    TEST_CONNECTION_EMBEDDING_SIZE = 1
+    DEFAULT_EMBEDDING_SIZE = 2

--- a/src/unstract/adapters/vectordb/helper.py
+++ b/src/unstract/adapters/vectordb/helper.py
@@ -97,7 +97,7 @@ class VectorDBHelper:
             vector_db_collection_name = (
                 vector_db_collection_name + "_" + str(embedding_dimension)
             )
-        if collection_name_prefix is not None:
+        if collection_name_prefix:
             vector_db_collection_name = (
                 collection_name_prefix + vector_db_collection_name
             )

--- a/src/unstract/adapters/vectordb/helper.py
+++ b/src/unstract/adapters/vectordb/helper.py
@@ -93,7 +93,7 @@ class VectorDBHelper:
 
         """
         vector_db_collection_name: str = VectorDbConstants.DEFAULT_VECTOR_DB_NAME
-        if embedding_dimension is not None:
+        if embedding_dimension:
             vector_db_collection_name = (
                 vector_db_collection_name + "_" + str(embedding_dimension)
             )

--- a/src/unstract/adapters/vectordb/helper.py
+++ b/src/unstract/adapters/vectordb/helper.py
@@ -34,7 +34,9 @@ class VectorDBHelper:
             #     chunk_size - 512
             #     llm=None
             llm = MockLLM()
-            embed_model = MockEmbedding(embed_dim=1)
+            embed_model = MockEmbedding(
+                embed_dim=VectorDbConstants.DEFAULT_EMBEDDING_SIZE
+            )
             index = VectorStoreIndex.from_documents(
                 # By default, SimpleDirectoryReader discards paths which
                 # contain one or more parts that are hidden.

--- a/src/unstract/adapters/vectordb/helper.py
+++ b/src/unstract/adapters/vectordb/helper.py
@@ -93,13 +93,13 @@ class VectorDBHelper:
 
         """
         vector_db_collection_name: str = VectorDbConstants.DEFAULT_VECTOR_DB_NAME
-        if collection_name_prefix is not None and embedding_dimension is not None:
+        if embedding_dimension is not None:
             vector_db_collection_name = (
-                collection_name_prefix
-                + "_"
-                + VectorDbConstants.DEFAULT_VECTOR_DB_NAME
-                + "_"
-                + str(embedding_dimension)
+                vector_db_collection_name + "_" + str(embedding_dimension)
+            )
+        if collection_name_prefix is not None:
+            vector_db_collection_name = (
+                collection_name_prefix + vector_db_collection_name
             )
         logger.info(f"Vector DB name: {vector_db_collection_name}")
         return vector_db_collection_name

--- a/src/unstract/adapters/vectordb/milvus/src/milvus.py
+++ b/src/unstract/adapters/vectordb/milvus/src/milvus.py
@@ -53,13 +53,13 @@ class Milvus(VectorDBAdapter):
 
     def _get_vector_db_instance(self) -> VectorStore:
         try:
-            self._collection_name = VectorDBHelper.get_collection_name(
-                self._config.get(VectorDbConstants.VECTOR_DB_NAME),
-                self._config.get(VectorDbConstants.EMBEDDING_DIMENSION),
-            )
             dimension = self._config.get(
                 VectorDbConstants.EMBEDDING_DIMENSION,
                 VectorDbConstants.DEFAULT_EMBEDDING_SIZE,
+            )
+            self._collection_name = VectorDBHelper.get_collection_name(
+                self._config.get(VectorDbConstants.VECTOR_DB_NAME),
+                dimension,
             )
             vector_db: VectorStore = MilvusVectorStore(
                 uri=self._config.get(Constants.URI, ""),
@@ -74,9 +74,6 @@ class Milvus(VectorDBAdapter):
             raise AdapterError(str(e))
 
     def test_connection(self) -> bool:
-        self._config[VectorDbConstants.EMBEDDING_DIMENSION] = (
-            VectorDbConstants.TEST_CONNECTION_EMBEDDING_SIZE
-        )
         vector_db = self.get_vector_db_instance()
         test_result: bool = VectorDBHelper.test_vector_db_instance(
             vector_store=vector_db

--- a/src/unstract/adapters/vectordb/pinecone/src/pinecone.py
+++ b/src/unstract/adapters/vectordb/pinecone/src/pinecone.py
@@ -71,15 +71,15 @@ class Pinecone(VectorDBAdapter):
         self._client = LLamaIndexPinecone(
             api_key=str(self._config.get(Constants.API_KEY))
         )
-        collection_name = VectorDBHelper.get_collection_name(
-            self._config.get(VectorDbConstants.VECTOR_DB_NAME),
-            self._config.get(VectorDbConstants.EMBEDDING_DIMENSION),
-        )
-        self._collection_name = collection_name.replace("_", "-").lower()
         dimension = self._config.get(
             VectorDbConstants.EMBEDDING_DIMENSION,
             VectorDbConstants.DEFAULT_EMBEDDING_SIZE,
         )
+        collection_name = VectorDBHelper.get_collection_name(
+            self._config.get(VectorDbConstants.VECTOR_DB_NAME),
+            dimension,
+        )
+        self._collection_name = collection_name.replace("_", "-").lower()
 
         specification = self._config.get(Constants.SPECIFICATION)
         if specification == Constants.SPEC_POD:
@@ -114,9 +114,6 @@ class Pinecone(VectorDBAdapter):
         return self.vector_db
 
     def test_connection(self) -> bool:
-        self._config[VectorDbConstants.EMBEDDING_DIMENSION] = (
-            VectorDbConstants.TEST_CONNECTION_EMBEDDING_SIZE
-        )
         vector_db = self.get_vector_db_instance()
         test_result: bool = VectorDBHelper.test_vector_db_instance(
             vector_store=vector_db

--- a/src/unstract/adapters/vectordb/postgres/src/postgres.py
+++ b/src/unstract/adapters/vectordb/postgres/src/postgres.py
@@ -58,17 +58,18 @@ class Postgres(VectorDBAdapter):
 
     def _get_vector_db_instance(self) -> BasePydanticVectorStore:
         try:
+
+            dimension = self._config.get(
+                VectorDbConstants.EMBEDDING_DIMENSION,
+                VectorDbConstants.DEFAULT_EMBEDDING_SIZE,
+            )
             self._collection_name = VectorDBHelper.get_collection_name(
                 self._config.get(VectorDbConstants.VECTOR_DB_NAME),
-                self._config.get(VectorDbConstants.EMBEDDING_DIMENSION),
+                dimension,
             )
             self._schema_name = self._config.get(
                 Constants.SCHEMA,
                 VectorDbConstants.DEFAULT_VECTOR_DB_NAME,
-            )
-            dimension = self._config.get(
-                VectorDbConstants.EMBEDDING_DIMENSION,
-                VectorDbConstants.DEFAULT_EMBEDDING_SIZE,
             )
             vector_db: BasePydanticVectorStore = PGVectorStore.from_params(
                 database=self._config.get(Constants.DATABASE),
@@ -93,9 +94,6 @@ class Postgres(VectorDBAdapter):
             raise AdapterError(str(e))
 
     def test_connection(self) -> bool:
-        self._config[VectorDbConstants.EMBEDDING_DIMENSION] = (
-            VectorDbConstants.TEST_CONNECTION_EMBEDDING_SIZE
-        )
         vector_db = self.get_vector_db_instance()
         test_result: bool = VectorDBHelper.test_vector_db_instance(
             vector_store=vector_db
@@ -106,9 +104,6 @@ class Postgres(VectorDBAdapter):
             self._client.cursor().execute(
                 f"DROP TABLE IF EXISTS "
                 f"{self._schema_name}.data_{self._collection_name} CASCADE"
-            )
-            self._client.cursor().execute(
-                f"DROP SCHEMA IF EXISTS {self._schema_name} CASCADE"
             )
             self._client.commit()
 

--- a/src/unstract/adapters/vectordb/supabase/src/supabase.py
+++ b/src/unstract/adapters/vectordb/supabase/src/supabase.py
@@ -56,11 +56,16 @@ class Supabase(VectorDBAdapter):
 
     def _get_vector_db_instance(self) -> VectorStore:
         try:
+
+            dimension = self._config.get(
+                VectorDbConstants.EMBEDDING_DIMENSION,
+                VectorDbConstants.DEFAULT_EMBEDDING_SIZE,
+            )
             self._collection_name = VectorDBHelper.get_collection_name(
                 self._config.get(VectorDbConstants.VECTOR_DB_NAME),
                 self._config.get(
                     VectorDbConstants.EMBEDDING_DIMENSION,
-                    VectorDbConstants.DEFAULT_EMBEDDING_SIZE,
+                    dimension,
                 ),
             )
             user = str(self._config.get(Constants.USER))
@@ -71,10 +76,6 @@ class Supabase(VectorDBAdapter):
 
             postgres_connection_string = (
                 f"postgresql://{user}:{password}@{host}:{port}/{db_name}"
-            )
-            dimension = self._config.get(
-                VectorDbConstants.EMBEDDING_DIMENSION,
-                VectorDbConstants.DEFAULT_EMBEDDING_SIZE,
             )
             vector_db: VectorStore = SupabaseVectorStore(
                 postgres_connection_string=postgres_connection_string,
@@ -88,9 +89,6 @@ class Supabase(VectorDBAdapter):
             raise AdapterError(str(e))
 
     def test_connection(self) -> bool:
-        self._config[VectorDbConstants.EMBEDDING_DIMENSION] = (
-            VectorDbConstants.TEST_CONNECTION_EMBEDDING_SIZE
-        )
         vector_db = self.get_vector_db_instance()
         test_result: bool = VectorDBHelper.test_vector_db_instance(
             vector_store=vector_db

--- a/src/unstract/adapters/vectordb/weaviate/src/weaviate.py
+++ b/src/unstract/adapters/vectordb/weaviate/src/weaviate.py
@@ -95,9 +95,6 @@ class Weaviate(VectorDBAdapter):
             raise AdapterError(str(e))
 
     def test_connection(self) -> bool:
-        self._config[VectorDbConstants.EMBEDDING_DIMENSION] = (
-            VectorDbConstants.TEST_CONNECTION_EMBEDDING_SIZE
-        )
         vector_db = self.get_vector_db_instance()
         test_result: bool = VectorDBHelper.test_vector_db_instance(
             vector_store=vector_db


### PR DESCRIPTION
## What

Fix dimension of the index created for test connection to support  Milvus

## Why

Milvus currently allows dimensions for index starting from 2. Earlier, for test connection, we were creating index with size 1. This will need changes across vector DB where dimension is supported. Some cleanup also was done as aprt of this PR.

## How

Change the default dimension value to 2.

## Relevant Docs

-

## Related Issues or PRs

- https://github.com/Zipstack/unstract-sdk/pull/62

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/74f91d68-4722-4478-839c-0781a87ffa01)


## Checklist

I have read and understood the [Contribution Guidelines]().
