### PR TITLE
Fix vector db index naming

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 import logging
 from logging import NullHandler

--- a/src/unstract/adapters/vectordb/helper.py
+++ b/src/unstract/adapters/vectordb/helper.py
@@ -99,7 +99,7 @@ class VectorDBHelper:
             )
         if collection_name_prefix:
             vector_db_collection_name = (
-                collection_name_prefix + vector_db_collection_name
+                collection_name_prefix + "_" + vector_db_collection_name
             )
         logger.info(f"Vector DB name: {vector_db_collection_name}")
         return vector_db_collection_name


### PR DESCRIPTION
## What

Vector DB index naming used to follow the convention org-id_unstract_embedding dimension. Eg org_36489_unstract_1536. However this naming convention got broken with a recent cleanup that happened. Now, vector db index name looks like org-idunstract_embedding dimension. Eg org_36489unstract_1536. One of the underscores got removed.

## Why

Better to follow one naming convention everywhere

## How

Fix the missing underscore

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

Indexed a doc and checked the vector DB for index name.

## Screenshots

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/d47d6014-7d62-42ad-8f08-10f322f850a2)


## Checklist

I have read and understood the [Contribution Guidelines]().
