### PR TITLE
LLM Whisperer - Support Pages to extract

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.20.1"
+__version__ = "0.21.0"
 
 import logging
 from logging import NullHandler

--- a/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/constants.py
@@ -59,6 +59,7 @@ class WhispererConfig:
     FORCE_TEXT_PROCESSING = "force_text_processing"
     LINE_SPLITTER_TOLERANCE = "line_splitter_tolerance"
     HORIZONTAL_STRETCH_FACTOR = "horizontal_stretch_factor"
+    PAGES_TO_EXTRACT = "pages_to_extract"
     STORE_METADATA_FOR_HIGHLIGHTING = "store_metadata_for_highlighting"
 
 
@@ -84,3 +85,4 @@ class WhispererDefaults:
     HORIZONTAL_STRETCH_FACTOR = 1.0
     POLL_INTERVAL = int(os.getenv(WhispererEnv.POLL_INTERVAL, 30))
     MAX_POLLS = int(os.getenv(WhispererEnv.MAX_POLLS, 30))
+    PAGES_TO_EXTRACT = ""

--- a/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/llm_whisperer.py
@@ -155,6 +155,10 @@ class LLMWhisperer(X2TextAdapter):
                 WhispererConfig.HORIZONTAL_STRETCH_FACTOR,
                 WhispererDefaults.HORIZONTAL_STRETCH_FACTOR,
             ),
+            WhispererConfig.PAGES_TO_EXTRACT: self.config.get(
+                WhispererConfig.PAGES_TO_EXTRACT,
+                WhispererDefaults.PAGES_TO_EXTRACT,
+            ),
         }
         if not params[WhispererConfig.FORCE_TEXT_PROCESSING]:
             params.update(
@@ -338,7 +342,8 @@ class LLMWhisperer(X2TextAdapter):
         """
 
         response: requests.Response = self._send_whisper_request(
-            input_file_path, bool(kwargs.get(X2TextConstants.ENABLE_HIGHLIGHT, False))
+            input_file_path,
+            bool(kwargs.get(X2TextConstants.ENABLE_HIGHLIGHT, False)),
         )
 
         metadata = TextExtractionMetadata(

--- a/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -57,18 +57,18 @@
       "type": "integer",
       "title": "Median Filter Size",
       "default": 0,
-      "description": "The size of the median filter to use for pre-processing the image during OCR based extraction. Useful to eliminate scanning artifacts and low quality JPEG artifacts. Default is 0 if the value is not explicitly set."
+      "description": "The size of the median filter to use for pre-processing the image during OCR based extraction. Useful to eliminate scanning artifacts and low quality JPEG artifacts. Default is 0 if the value is not explicitly set. Available only in the Enterprise version."
     },
     "gaussian_blur_radius": {
       "type": "number",
       "title": "Gaussian Blur Radius",
       "default": 0.0,
-      "description": "The radius of the gaussian blur to use for pre-processing the image during OCR based extraction. Useful to eliminate noise from the image. Default is 0.0 if the value is not explicitly set."
+      "description": "The radius of the gaussian blur to use for pre-processing the image during OCR based extraction. Useful to eliminate noise from the image. Default is 0.0 if the value is not explicitly set. Available only in the Enterprise version."
     },
     "line_splitter_tolerance": {
       "type": "number",
       "title": "Line Splitter Tolerance",
-      "default": 0.75,
+      "default": 0.4,
       "description": "Reduce this value to split lines less often, increase to split lines more often. Useful when PDFs have multi column layout with text in each column that is not aligned."
     },
     "horizontal_stretch_factor": {
@@ -76,6 +76,13 @@
       "title": "Horizontal Stretch Factor",
       "default": 1.0,
       "description": "Increase this value to stretch text horizontally, decrease to compress text horizontally. Useful when multi column text merge with each other."
+    },
+    "pages_to_extract": {
+      "type": "string",
+      "title": "Page number(s) or range to extract",
+      "default": "",
+       "pattern": "^[\\d\\s]+[\\d\\-,\\s]*",
+      "description": "Specify the range of pages to extract (e.g., 1-5, 7, 10-12, 50-). Leave it empty to extract all pages."
     }
   },
   "if": {


### PR DESCRIPTION
## What

1. Add pages_to_extract with minimal validation to allow hyphen, comma and numbers
2. Add helper text to say that "Available only in the enterprise version" for median_filter_size and gaussian_blur_radius
3. Default line splitter tolerance to 0.4

## Why

To help customer specify the range of pages to extract from the document

## How

Add the param while sending the request to LLM Whisperer service

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

- 

## Notes on Testing

Please refer to the screenshots

## Screenshots

Setting up LLM Whisperer with new pages_to_extract

Setting up with only first page to extract

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/626bf97e-b03a-44c7-a632-04aff74c6170)

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/a198eb48-df5a-4daf-a874-bed245d510f5)

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/61b40a8c-51e2-479d-91ee-732cffbe38dc)

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/f9005647-120d-45c8-8572-f4da232a21bd)


Extracting only page 2

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/68472899-c7b7-49ad-81d9-4f91f4f00065)

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/b273bc37-6aa6-4744-ae9a-37d892d4d8a7)


Setting up with all pages_to_extract

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/1b0225d7-2897-4e12-8587-918a3a85b7f4)

Extracted all pages

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/b07fe64d-840e-49fb-b60c-dfc8464067aa)

Error reporting for wrong formats for pages_to_extract

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/d65cc25b-6222-43ec-a514-761f2ac26612)




## Checklist

I have read and understood the [Contribution Guidelines]().
