### PR TITLE
Add URL param to ollama embedding

### DIFF
--- a/src/unstract/adapters/embedding/ollama/src/ollama.py
+++ b/src/unstract/adapters/embedding/ollama/src/ollama.py
@@ -13,6 +13,7 @@ from unstract.adapters.exceptions import AdapterError
 class Constants:
     MODEL = "model_name"
     ADAPTER_NAME = "adapter_name"
+    BASE_URL = "base_url"
 
 
 class Ollama(EmbeddingAdapter):
@@ -51,6 +52,7 @@ class Ollama(EmbeddingAdapter):
             )
             embedding: BaseEmbedding = OllamaEmbedding(
                 model_name=str(self.config.get(Constants.MODEL)),
+                base_url=str(self.config.get(Constants.BASE_URL)),
                 embed_batch_size=embedding_batch_size,
             )
             return embedding

--- a/src/unstract/adapters/embedding/ollama/src/static/json_schema.json
+++ b/src/unstract/adapters/embedding/ollama/src/static/json_schema.json
@@ -21,7 +21,7 @@
     "base_url": {
       "type": "string",
       "title": "Base URL",
-      "default": "",
+      "default": "http://localhost:11434",
       "description": "Provide the base URL where Ollama server is running."
     },
     "embed_batch_size": {

--- a/src/unstract/adapters/embedding/ollama/src/static/json_schema.json
+++ b/src/unstract/adapters/embedding/ollama/src/static/json_schema.json
@@ -21,8 +21,8 @@
     "base_url": {
       "type": "string",
       "title": "Base URL",
-      "default": "http://localhost:11434",
-      "description": "Provide the base URL where Ollama server is running."
+      "default": "",
+      "description": "Provide the base URL where Ollama server is running. Example: http://docker.host.internal:11434 or http://localhost:11434"
     },
     "embed_batch_size": {
       "type": "number",

--- a/src/unstract/adapters/embedding/ollama/src/static/json_schema.json
+++ b/src/unstract/adapters/embedding/ollama/src/static/json_schema.json
@@ -3,6 +3,7 @@
   "type": "object",
   "required": [
     "adapter_name",
+    "base_url",
     "model_name"
   ],
   "properties": {

--- a/src/unstract/adapters/embedding/ollama/src/static/json_schema.json
+++ b/src/unstract/adapters/embedding/ollama/src/static/json_schema.json
@@ -18,6 +18,12 @@
       "default": "mxbai-embed-large",
       "description": "Provide the name of the model to use for embedding. Example: mxbai-embed-large"
     },
+    "base_url": {
+      "type": "string",
+      "title": "Base URL",
+      "default": "",
+      "description": "Provide the base URL where Ollama server is running."
+    },
     "embed_batch_size": {
       "type": "number",
       "minimum": 0,

--- a/src/unstract/adapters/llm/ollama/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/ollama/src/static/json_schema.json
@@ -22,7 +22,7 @@
       "type": "string",
       "title": "Base URL",
       "default": "",
-      "description": "Provide the base URL where Ollama server is running."
+      "description": "Provide the base URL where Ollama server is running. Example: http://docker.host.internal:11434 or http://localhost:11434"
     },
     "context_window": {
       "type": "number",

--- a/src/unstract/adapters/llm/ollama/src/static/json_schema.json
+++ b/src/unstract/adapters/llm/ollama/src/static/json_schema.json
@@ -2,6 +2,7 @@
   "title": "Ollama AI LLM",
   "type": "object",
   "required": [
+    "adapter_name",
     "base_url",
     "model"
   ],


### PR DESCRIPTION
## What

Add additonal URL parama to configuration of ollama embedding

## Why

Users should be able to point to a setup where the ollama server is running. Cannot be always on the same machine (localhost)

## How

Expose a new UI field

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

Please refer to the screenshot

## Screenshots

![image](https://github.com/Zipstack/unstract-adapters/assets/142381512/0c3fe9fa-c2cb-45df-a978-7681db29664f)


## Checklist

I have read and understood the [Contribution Guidelines]().
