### PR TITLE
Fix regex pattern for pages to extract in LLMWhisperer

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 
 import logging
 from logging import NullHandler

--- a/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -81,7 +81,7 @@
       "type": "string",
       "title": "Page number(s) or range to extract",
       "default": "",
-       "pattern": "^[\\d\\s]+[\\d\\-,\\s]*",
+      "pattern": "^(\\s|\\d+)[\\d\\-,\\s]*",
       "description": "Specify the range of pages to extract (e.g., 1-5, 7, 10-12, 50-). Leave it empty to extract all pages."
     }
   },


### PR DESCRIPTION
## What

Fix regex pattern for validating pages to extract in LLMWhisperer adapter

## Why

The field was not taking empty as a valid value and was forcing user to enter an empty space

## How

Change regex pattern used for validation

## Relevant Docs

-

## Related Issues or PRs

- https://zipstack.atlassian.net/browse/UN-1452

## Dependencies Versions / Env Variables

-

## Notes on Testing

...

## Screenshots

...

## Checklist

I have read and understood the [Contribution Guidelines]().
