### PR TITLE
Fix regex validation for llm whisp pages to extract

### DIFF
--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 
 import logging
 from logging import NullHandler

--- a/src/unstract/adapters/__init__.py
+++ b/src/unstract/adapters/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.22.0"
+__version__ = "0.22.1"
 
 import logging
 from logging import NullHandler

--- a/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -81,7 +81,7 @@
       "type": "string",
       "title": "Page number(s) or range to extract",
       "default": "",
-       "pattern": "^[\\d\\s]+[\\d\\-,\\s]*",
+      "pattern": "^(\\s|\\d+)[\\d\\-,\\s]*",
       "description": "Specify the range of pages to extract (e.g., 1-5, 7, 10-12, 50-). Leave it empty to extract all pages."
     }
   },

--- a/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
+++ b/src/unstract/adapters/x2text/llm_whisperer/src/static/json_schema.json
@@ -81,8 +81,8 @@
       "type": "string",
       "title": "Page number(s) or range to extract",
       "default": "",
-      "pattern": "^(\\s|\\d+)[\\d\\-,\\s]*",
-      "description": "Specify the range of pages to extract (e.g., 1-5, 7, 10-12, 50-). Leave it empty to extract all pages."
+      "pattern": "^(\\s*\\d+-\\d+|\\s*\\d+-|\\s*\\d+|^$)(,\\d+-\\d+|,\\d+-|,\\d+)*$",
+      "description": "Specify the range of pages to extract (e.g., 1-5,7,10-12,50-). Leave it empty to extract all pages."
     }
   },
   "if": {


### PR DESCRIPTION
## What

Corrected Regex validation for pages to extract for LLM Whisperer adapter configuration 

## Why

Existing validation does not take default "empty"

## How

Fix the regex in the Json schema

## Relevant Docs

-

## Related Issues or PRs

-

## Dependencies Versions / Env Variables

-

## Notes on Testing

Write local unit testcases with the following values:

REGEX_POSITIVE_TEST_VALUES=["", "4-9", "4", "4,6", "4-6,9-10", "47-67,9-10,19", "4-"]
REGEX_NEGATIVE_TEST_VALUES=[" ", "-", ",", ",5", ",,", "-7", "6-7 ", "@"]

## Screenshots

![image](https://github.com/user-attachments/assets/7347b2c8-4054-464a-806c-3ab99bb26db0)

![image](https://github.com/user-attachments/assets/a630e50d-587f-43ab-8e98-828db314e57a)


## Checklist

I have read and understood the [Contribution Guidelines]().
